### PR TITLE
Cache implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out/
 target/
 *iml
 conf.json
+cache/

--- a/README.md
+++ b/README.md
@@ -23,5 +23,6 @@ This is more advanced and should only be used if you saved an authentication blo
 ## TODO
 The client is pretty functional as it is, but improvements can be made:
 - Have an user interface
+- ~Caching~ (#18)
 - Preloading
 - Gapless playing

--- a/README.md
+++ b/README.md
@@ -23,6 +23,5 @@ This is more advanced and should only be used if you saved an authentication blo
 ## TODO
 The client is pretty functional as it is, but improvements can be made:
 - Have an user interface
-- Caching
 - Preloading
 - Gapless playing

--- a/src/main/java/org/librespot/spotify/AbsConfiguration.java
+++ b/src/main/java/org/librespot/spotify/AbsConfiguration.java
@@ -1,0 +1,10 @@
+package org.librespot.spotify;
+
+import org.librespot.spotify.player.CacheManager;
+import org.librespot.spotify.player.Player;
+
+/**
+ * @author Gianlu
+ */
+public abstract class AbsConfiguration implements Player.PlayerConfiguration, CacheManager.CacheConfiguration {
+}

--- a/src/main/java/org/librespot/spotify/DefaultConfiguration.java
+++ b/src/main/java/org/librespot/spotify/DefaultConfiguration.java
@@ -1,0 +1,46 @@
+package org.librespot.spotify;
+
+import org.jetbrains.annotations.NotNull;
+import org.librespot.spotify.player.Player;
+
+import java.io.File;
+
+/**
+ * @author Gianlu
+ */
+public final class DefaultConfiguration extends AbsConfiguration {
+
+    //****************//
+    //---- PLAYER ----//
+    //****************//
+
+    @NotNull
+    @Override
+    public Player.AudioQuality preferredQuality() {
+        return Player.AudioQuality.VORBIS_320;
+    }
+
+    @Override
+    public float normalisationPregain() {
+        return 0;
+    }
+
+    @Override
+    public boolean pauseWhenLoading() {
+        return false;
+    }
+
+    //****************//
+    //---- CACHE -----//
+    //****************//
+
+    @Override
+    public boolean cacheEnabled() {
+        return true;
+    }
+
+    @Override
+    public @NotNull File cacheDir() {
+        return new File("./cache/");
+    }
+}

--- a/src/main/java/org/librespot/spotify/Main.java
+++ b/src/main/java/org/librespot/spotify/Main.java
@@ -13,7 +13,7 @@ import java.security.GeneralSecurityException;
 public class Main {
 
     public static void main(String[] args) throws IOException, GeneralSecurityException, Session.SpotifyAuthenticationException, SpotifyIrc.IrcException, MercuryClient.PubSubException {
-        Session session = new Session.Builder(Session.DeviceType.Computer, "librespot-java")
+        Session session = new Session.Builder(Session.DeviceType.Computer, "librespot-java", new DefaultConfiguration())
                 // .facebook()
                 // .zeroconf()
                 .userPass(args[0], args[1])

--- a/src/main/java/org/librespot/spotify/core/Session.java
+++ b/src/main/java/org/librespot/spotify/core/Session.java
@@ -3,6 +3,7 @@ package org.librespot.spotify.core;
 import com.google.protobuf.ByteString;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.librespot.spotify.AbsConfiguration;
 import org.librespot.spotify.Version;
 import org.librespot.spotify.crypto.CipherPair;
 import org.librespot.spotify.crypto.DiffieHellman;
@@ -217,7 +218,7 @@ public class Session implements AutoCloseable {
             audioKeyManager = new AudioKeyManager(this);
             channelManager = new ChannelManager(this);
             spirc = new SpotifyIrc(this);
-            player = new Player(this);
+            player = new Player(inner.configuration, inner.configuration, this);
 
             LOGGER.info(String.format("Authenticated as %s!", apWelcome.getCanonicalUsername()));
         } else if (packet.is(Packet.Type.AuthFailure)) {
@@ -341,10 +342,12 @@ public class Session implements AutoCloseable {
         final String deviceName;
         final SecureRandom random;
         final String deviceId;
+        final AbsConfiguration configuration;
 
-        private Inner(DeviceType deviceType, String deviceName) {
+        private Inner(DeviceType deviceType, String deviceName, AbsConfiguration configuration) {
             this.deviceType = deviceType;
             this.deviceName = deviceName;
+            this.configuration = configuration;
             this.random = new SecureRandom();
             this.deviceId = UUID.randomUUID().toString();
         }
@@ -399,8 +402,8 @@ public class Session implements AutoCloseable {
         private final Inner inner;
         private Authentication.LoginCredentials loginCredentials = null;
 
-        public Builder(@NotNull DeviceType deviceType, @NotNull String deviceName) {
-            this.inner = new Inner(deviceType, deviceName);
+        public Builder(@NotNull DeviceType deviceType, @NotNull String deviceName, @NotNull AbsConfiguration configuration) {
+            this.inner = new Inner(deviceType, deviceName, configuration);
         }
 
         public Builder facebook() throws IOException {

--- a/src/main/java/org/librespot/spotify/player/AudioFile.java
+++ b/src/main/java/org/librespot/spotify/player/AudioFile.java
@@ -1,5 +1,7 @@
 package org.librespot.spotify.player;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.io.IOException;
 
 /**
@@ -9,4 +11,6 @@ public interface AudioFile {
     void writeChunk(byte[] chunk, int chunkIndex) throws IOException;
 
     void header(byte id, byte[] bytes);
+
+    void cacheFailed(int index, @NotNull AudioFile file);
 }

--- a/src/main/java/org/librespot/spotify/player/AudioFileFetch.java
+++ b/src/main/java/org/librespot/spotify/player/AudioFileFetch.java
@@ -1,5 +1,7 @@
 package org.librespot.spotify.player;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.nio.ByteBuffer;
 
 /**
@@ -24,6 +26,11 @@ class AudioFileFetch implements AudioFile {
             size *= 4;
             notifyAll();
         }
+    }
+
+    @Override
+    public void cacheFailed(int index, @NotNull AudioFile file) {
+        // Never called
     }
 
     synchronized void waitChunk() {

--- a/src/main/java/org/librespot/spotify/player/AudioFileStreaming.java
+++ b/src/main/java/org/librespot/spotify/player/AudioFileStreaming.java
@@ -52,7 +52,14 @@ public class AudioFileStreaming implements AudioFile {
     }
 
     private int requestSize() throws IOException {
-        if (cacheHandler != null && cacheHandler.has(0)) return cacheHandler.requestSize();
+        if (cacheHandler != null && cacheHandler.has(0)) {
+            try {
+                return cacheHandler.requestSize();
+            } catch (IOException ex) {
+                LOGGER.warn("Failed loading track size from cache.", ex);
+                cacheHandler.remove();
+            }
+        }
 
         AudioFileFetch fetch = new AudioFileFetch();
         requestChunk(fileId, 0, fetch);

--- a/src/main/java/org/librespot/spotify/player/CacheManager.java
+++ b/src/main/java/org/librespot/spotify/player/CacheManager.java
@@ -1,0 +1,90 @@
+package org.librespot.spotify.player;
+
+import com.google.protobuf.ByteString;
+import org.apache.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.*;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.librespot.spotify.player.ChannelManager.CHUNK_SIZE;
+
+
+/**
+ * @author Gianlu
+ */
+public class CacheManager {
+    private static final Logger LOGGER = Logger.getLogger(CacheManager.class);
+    private final File cacheDir;
+    private final boolean enabled;
+    private final Map<String, Handler> loadedHandlers;
+
+    public CacheManager(@NotNull CacheConfiguration conf) {
+        this.enabled = conf.cacheEnabled();
+        if (enabled) {
+            this.loadedHandlers = new HashMap<>();
+            this.cacheDir = conf.cacheDir();
+            if (!cacheDir.exists() && !cacheDir.mkdir())
+                throw new IllegalStateException("Cannot created cache dir!");
+        } else {
+            this.cacheDir = null;
+            this.loadedHandlers = null;
+        }
+    }
+
+    @Nullable
+    public Handler handler(@NotNull ByteString fileId) {
+        if (!enabled) return null;
+        return loadedHandlers.computeIfAbsent(Base64.getEncoder().encodeToString(fileId.toByteArray()), Handler::new);
+    }
+
+    @Nullable
+    private RandomAccessFile readerFor(@NotNull String fileId) {
+        File file = new File(cacheDir, fileId);
+        if (file.exists()) {
+            try {
+                return new RandomAccessFile(file, "rw");
+            } catch (FileNotFoundException ex) {
+                LOGGER.fatal("Failed reading cache file: " + file, ex);
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    public interface CacheConfiguration {
+        boolean cacheEnabled();
+
+        @NotNull
+        File cacheDir();
+    }
+
+    public class Handler implements Closeable {
+        private final RandomAccessFile in;
+
+        private Handler(@NotNull String fileId) {
+            in = readerFor(fileId);
+        }
+
+        public boolean has(int chunk) {
+            return false;
+        }
+
+        @Override
+        public void close() throws IOException {
+            in.close();
+        }
+
+        private byte[] readChunk(int index) {
+            return new byte[CHUNK_SIZE];
+        }
+
+        public void requestChunk(int index, AudioFile file) throws IOException {
+            file.writeChunk(readChunk(index), index);
+        }
+    }
+}

--- a/src/main/java/org/librespot/spotify/player/CacheManager.java
+++ b/src/main/java/org/librespot/spotify/player/CacheManager.java
@@ -6,9 +6,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.librespot.spotify.player.ChannelManager.CHUNK_SIZE;
 
@@ -21,39 +21,36 @@ public class CacheManager {
     private final File cacheDir;
     private final boolean enabled;
     private final Map<String, Handler> loadedHandlers;
+    private final ControlTable controlTable;
+    private final ExecutorService executorService = Executors.newCachedThreadPool();
 
-    public CacheManager(@NotNull CacheConfiguration conf) {
+    public CacheManager(@NotNull CacheConfiguration conf) throws IOException, ClassNotFoundException {
         this.enabled = conf.cacheEnabled();
         if (enabled) {
             this.loadedHandlers = new HashMap<>();
             this.cacheDir = conf.cacheDir();
             if (!cacheDir.exists() && !cacheDir.mkdir())
-                throw new IllegalStateException("Cannot created cache dir!");
+                throw new IllegalStateException("Cannot create cache dir!");
+
+            this.controlTable = new ControlTable(new File(cacheDir, ".table"));
         } else {
             this.cacheDir = null;
             this.loadedHandlers = null;
+            this.controlTable = null;
         }
     }
 
     @Nullable
     public Handler handler(@NotNull ByteString fileId) {
         if (!enabled) return null;
-        return loadedHandlers.computeIfAbsent(Base64.getEncoder().encodeToString(fileId.toByteArray()), Handler::new);
-    }
-
-    @Nullable
-    private RandomAccessFile readerFor(@NotNull String fileId) {
-        File file = new File(cacheDir, fileId);
-        if (file.exists()) {
+        return loadedHandlers.computeIfAbsent(Base64.getEncoder().encodeToString(fileId.toByteArray()), id -> {
             try {
-                return new RandomAccessFile(file, "rw");
-            } catch (FileNotFoundException ex) {
-                LOGGER.fatal("Failed reading cache file: " + file, ex);
+                return new Handler(id);
+            } catch (IOException ex) {
+                LOGGER.fatal("Failed creating cache handler for " + fileId, ex);
                 return null;
             }
-        } else {
-            return null;
-        }
+        });
     }
 
     public interface CacheConfiguration {
@@ -63,28 +60,99 @@ public class CacheManager {
         File cacheDir();
     }
 
-    public class Handler implements Closeable {
-        private final RandomAccessFile in;
+    private class ControlTable {
+        private final HashMap<String, ArrayList<Integer>> map;
+        private final File controlFile;
 
-        private Handler(@NotNull String fileId) {
-            in = readerFor(fileId);
+        private ControlTable(@NotNull File controlFile) throws IOException, ClassNotFoundException {
+            this.controlFile = controlFile;
+
+            if (!controlFile.exists()) {
+                if (controlFile.createNewFile()) map = new HashMap<>();
+                else throw new IOException("Failed creating cache control file!");
+                save();
+            } else {
+                try (ObjectInputStream in = new ObjectInputStream(new FileInputStream(controlFile))) {
+                    map = (HashMap<String, ArrayList<Integer>>) in.readObject();
+                }
+            }
+        }
+
+        private void save() throws IOException {
+            try (ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(controlFile))) {
+                out.writeObject(map);
+            }
+        }
+
+        boolean has(@NotNull String fileId, int chunk) {
+            List<Integer> list = map.get(fileId);
+            return list != null && list.contains(chunk);
+        }
+
+        void written(@NotNull String fileId, int index) {
+            List<Integer> list = map.computeIfAbsent(fileId, s -> new ArrayList<>());
+            list.add(index);
+
+            try {
+                save();
+            } catch (IOException ex) {
+                LOGGER.warn("Failed saving cache control file!", ex);
+            }
+        }
+    }
+
+    public class Handler implements Closeable {
+        private final RandomAccessFile cache;
+        private final String fileId;
+
+        private Handler(@NotNull String fileId) throws IOException {
+            this.fileId = fileId;
+
+            File file = new File(cacheDir, fileId);
+            if (!file.exists() && !file.createNewFile())
+                throw new IOException("Failed creating cache file for " + fileId);
+
+            cache = new RandomAccessFile(file, "rw");
         }
 
         public boolean has(int chunk) {
-            return false;
+            return controlTable.has(fileId, chunk);
         }
 
         @Override
         public void close() throws IOException {
-            in.close();
+            cache.close();
         }
 
-        private byte[] readChunk(int index) {
-            return new byte[CHUNK_SIZE];
+        public int requestSize() throws IOException {
+            cache.seek(0);
+            return cache.readInt() * 4;
         }
 
-        public void requestChunk(int index, AudioFile file) throws IOException {
-            file.writeChunk(readChunk(index), index);
+        public void requestChunk(int index, @NotNull AudioFile file) {
+            executorService.execute(() -> {
+                try {
+                    cache.seek(index * CHUNK_SIZE + 4);
+                    byte[] buffer = new byte[CHUNK_SIZE];
+                    cache.readFully(buffer);
+                    file.writeChunk(buffer, index);
+                } catch (IOException ex) {
+                    LOGGER.fatal("Failed reading chunk, index: " + index, ex);
+                    file.cacheFailed(index, file);
+                }
+            });
+        }
+
+        public void writeSize(int size) throws IOException {
+            size /= 4;
+            cache.seek(0);
+            cache.writeInt(size);
+        }
+
+        public void write(byte[] buffer, int index) throws IOException {
+            cache.seek(index * CHUNK_SIZE + 4);
+            cache.write(buffer);
+            controlTable.written(fileId, index);
         }
     }
 }

--- a/src/main/java/org/librespot/spotify/player/ChannelManager.java
+++ b/src/main/java/org/librespot/spotify/player/ChannelManager.java
@@ -30,7 +30,7 @@ public class ChannelManager extends PacketsManager {
         super(session);
     }
 
-    void requestChunk(ByteString fileId, int index, AudioFile file) throws IOException {
+    void requestChunk(@NotNull ByteString fileId, int index, @NotNull AudioFile file) throws IOException {
         int start = index * CHUNK_SIZE / 4;
         int end = (index + 1) * CHUNK_SIZE / 4;
 

--- a/src/main/java/org/librespot/spotify/player/NormalizationData.java
+++ b/src/main/java/org/librespot/spotify/player/NormalizationData.java
@@ -42,8 +42,8 @@ public class NormalizationData {
         return new NormalizationData(buffer.getFloat(), buffer.getFloat(), buffer.getFloat(), buffer.getFloat());
     }
 
-    public float getFactor(@NotNull Player.Configuration config) {
-        float normalisationFactor = (float) Math.pow(10, (track_gain_db + config.normalisationPregain) / 20);
+    public float getFactor(@NotNull Player.PlayerConfiguration config) {
+        float normalisationFactor = (float) Math.pow(10, (track_gain_db + config.normalisationPregain()) / 20);
         if (normalisationFactor * track_peak > 1) {
             LOGGER.warn("Reducing normalisation factor to prevent clipping. Please add negative pregain to avoid.");
             normalisationFactor = 1 / track_peak;

--- a/src/main/java/org/librespot/spotify/player/Player.java
+++ b/src/main/java/org/librespot/spotify/player/Player.java
@@ -37,7 +37,12 @@ public class Player implements FrameListener, PlayerRunner.Listener {
         this.session = session;
         this.spirc = session.spirc();
         this.state = initState();
-        this.cacheManager = new CacheManager(cacheConfiguration);
+
+        try {
+            this.cacheManager = new CacheManager(cacheConfiguration);
+        } catch (IOException | ClassNotFoundException ex) {
+            throw new RuntimeException(ex);
+        }
 
         spirc.addListener(this);
     }

--- a/src/main/java/org/librespot/spotify/player/Player.java
+++ b/src/main/java/org/librespot/spotify/player/Player.java
@@ -28,13 +28,16 @@ public class Player implements FrameListener, PlayerRunner.Listener {
     private final Session session;
     private final SpotifyIrc spirc;
     private final Spirc.State.Builder state;
-    private final Configuration conf = new Configuration();
+    private final PlayerConfiguration conf;
+    private final CacheManager cacheManager;
     private PlayerRunner playerRunner;
 
-    public Player(@NotNull Session session) {
+    public Player(@NotNull PlayerConfiguration conf, @NotNull CacheManager.CacheConfiguration cacheConfiguration, @NotNull Session session) {
+        this.conf = conf;
         this.session = session;
         this.spirc = session.spirc();
         this.state = initState();
+        this.cacheManager = new CacheManager(cacheConfiguration);
 
         spirc.addListener(this);
     }
@@ -132,7 +135,7 @@ public class Player implements FrameListener, PlayerRunner.Listener {
 
     private void handlePrev() {
         if (getPosition() < 3000) {
-            if (conf.pauseWhenLoading) {
+            if (conf.pauseWhenLoading()) {
                 handlePause();
                 stateUpdated();
             }
@@ -216,7 +219,7 @@ public class Player implements FrameListener, PlayerRunner.Listener {
 
         LOGGER.info(String.format("Loading track, name: '%s', artists: '%s', play: %b, pos: %d", track.getName(), Utils.toString(track.getArtistList()), play, pos));
 
-        Metadata.AudioFile file = conf.preferredQuality.getFile(track);
+        Metadata.AudioFile file = conf.preferredQuality().getFile(track);
         if (file == null) {
             file = AudioQuality.getAnyVorbisFile(track);
             if (file == null) {
@@ -224,12 +227,12 @@ public class Player implements FrameListener, PlayerRunner.Listener {
                 state.setStatus(Spirc.PlayStatus.kPlayStatusStop);
                 return;
             } else {
-                LOGGER.warn(String.format("Using %s because preferred %s couldn't be found.", file, conf.preferredQuality));
+                LOGGER.warn(String.format("Using %s because preferred %s couldn't be found.", file, conf.preferredQuality()));
             }
         }
 
         byte[] key = session.audioKey().getAudioKey(track, file);
-        AudioFileStreaming audioStreaming = new AudioFileStreaming(session, file, key);
+        AudioFileStreaming audioStreaming = new AudioFileStreaming(session, cacheManager, file, key);
         audioStreaming.open();
 
         InputStream in = audioStreaming.stream();
@@ -274,7 +277,7 @@ public class Player implements FrameListener, PlayerRunner.Listener {
                     .setIsActive(true)
                     .setBecameActiveAt(System.currentTimeMillis());
         } else {
-            if (conf.pauseWhenLoading) {
+            if (conf.pauseWhenLoading()) {
                 handlePause();
                 stateUpdated();
             }
@@ -332,7 +335,7 @@ public class Player implements FrameListener, PlayerRunner.Listener {
     }
 
     private void handleNext(boolean forced) {
-        if (forced && conf.pauseWhenLoading) {
+        if (forced && conf.pauseWhenLoading()) {
             handlePause();
             stateUpdated();
         }
@@ -382,7 +385,7 @@ public class Player implements FrameListener, PlayerRunner.Listener {
         LOGGER.fatal("Playback failed!", ex);
     }
 
-    private enum AudioQuality {
+    public enum AudioQuality {
         VORBIS_96(Metadata.AudioFile.Format.OGG_VORBIS_96),
         VORBIS_160(Metadata.AudioFile.Format.OGG_VORBIS_160),
         VORBIS_320(Metadata.AudioFile.Format.OGG_VORBIS_320);
@@ -425,15 +428,12 @@ public class Player implements FrameListener, PlayerRunner.Listener {
         }
     }
 
-    public static class Configuration {
-        public final AudioQuality preferredQuality;
-        public final float normalisationPregain;
-        public final boolean pauseWhenLoading;
+    public interface PlayerConfiguration {
+        @NotNull
+        AudioQuality preferredQuality();
 
-        public Configuration() {
-            this.preferredQuality = AudioQuality.VORBIS_320;
-            this.normalisationPregain = 0;
-            this.pauseWhenLoading = false;
-        }
+        float normalisationPregain();
+
+        boolean pauseWhenLoading();
     }
 }

--- a/src/main/java/org/librespot/spotify/player/PlayerRunner.java
+++ b/src/main/java/org/librespot/spotify/player/PlayerRunner.java
@@ -52,7 +52,7 @@ public class PlayerRunner implements Runnable {
     private volatile boolean notifiedPlaybackReady = false;
 
     public PlayerRunner(@NotNull AudioFileStreaming audioFile, @NotNull NormalizationData normalizationData, @NotNull Spirc.DeviceState.Builder deviceState,
-                        @NotNull Player.Configuration configuration, @NotNull Listener listener, int duration) throws IOException, PlayerException {
+                        @NotNull Player.PlayerConfiguration configuration, @NotNull Listener listener, int duration) throws IOException, PlayerException {
         this.audioIn = audioFile.stream();
         this.listener = listener;
         this.normalizationFactor = normalizationData.getFactor(configuration);


### PR DESCRIPTION
Implemented a cache for the client. 

N.B.
- This is not compatible with the original Spotify cache
- The first 4 bytes of the cache make up an int which is the size of the track divided by 4
- ~Arbitrarily deleting files from the cache will break it~ (c278acdd3ca5e90158b1886810aba4cf273ebedd)