### PR TITLE
Send loading event the moment librespot-java calls load()

### DIFF
--- a/core/src/main/java/xyz/gianlu/librespot/player/Player.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/Player.java
@@ -264,6 +264,12 @@ public class Player implements FrameListener, TrackHandler.Listener, Closeable {
     }
 
     @Override
+    public void startedLoading() {
+        state.setStatus(Spirc.PlayStatus.kPlayStatusLoading);
+        stateUpdated();
+    }
+
+    @Override
     public void finishedLoading(@NotNull TrackHandler handler, int pos, boolean play) {
         if (handler == trackHandler) {
             if (play) state.setStatus(Spirc.PlayStatus.kPlayStatusPlay);

--- a/core/src/main/java/xyz/gianlu/librespot/player/Player.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/Player.java
@@ -264,9 +264,11 @@ public class Player implements FrameListener, TrackHandler.Listener, Closeable {
     }
 
     @Override
-    public void startedLoading() {
-        state.setStatus(Spirc.PlayStatus.kPlayStatusLoading);
-        stateUpdated();
+    public void startedLoading(@NotNull TrackHandler handler) {
+        if (handler == trackHandler) {
+            state.setStatus(Spirc.PlayStatus.kPlayStatusLoading);
+            stateUpdated();
+        }
     }
 
     @Override
@@ -349,7 +351,6 @@ public class Player implements FrameListener, TrackHandler.Listener, Closeable {
         } else {
             trackHandler = new TrackHandler(session, lines, cacheManager, conf, this);
             trackHandler.sendLoad(id, play, state.getPositionMs());
-            state.setStatus(Spirc.PlayStatus.kPlayStatusLoading);
         }
 
         if (play) {

--- a/core/src/main/java/xyz/gianlu/librespot/player/TrackHandler.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/TrackHandler.java
@@ -42,7 +42,8 @@ public class TrackHandler implements PlayerRunner.Listener, Closeable {
     }
 
     private void load(@NotNull TrackId id, boolean play, int pos) throws IOException, MercuryClient.MercuryException {
-        listener.startedLoading();
+        listener.startedLoading(this);
+
         StreamFeeder.LoadedStream stream = feeder.load(id, new StreamFeeder.VorbisOnlyAudioQuality(conf.preferredQuality()));
         track = stream.track;
 
@@ -143,7 +144,7 @@ public class TrackHandler implements PlayerRunner.Listener, Closeable {
     }
 
     public interface Listener {
-        void startedLoading();
+        void startedLoading(@NotNull TrackHandler handler);
 
         void finishedLoading(@NotNull TrackHandler handler, int pos, boolean play);
 

--- a/core/src/main/java/xyz/gianlu/librespot/player/TrackHandler.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/TrackHandler.java
@@ -42,6 +42,7 @@ public class TrackHandler implements PlayerRunner.Listener, Closeable {
     }
 
     private void load(@NotNull TrackId id, boolean play, int pos) throws IOException, MercuryClient.MercuryException {
+        listener.startedLoading();
         StreamFeeder.LoadedStream stream = feeder.load(id, new StreamFeeder.VorbisOnlyAudioQuality(conf.preferredQuality()));
         track = stream.track;
 
@@ -142,6 +143,8 @@ public class TrackHandler implements PlayerRunner.Listener, Closeable {
     }
 
     public interface Listener {
+        void startedLoading();
+
         void finishedLoading(@NotNull TrackHandler handler, int pos, boolean play);
 
         void loadingError(@NotNull TrackHandler handler, @NotNull TrackId track, @NotNull Exception ex);


### PR DESCRIPTION
Fixes couple of seconds playback of progress bar before resetting itself once song is actually loaded. If anyone has a slow connection, please test.