### PR TITLE
Let Spotify know the client supports podcasts

### DIFF
--- a/core/src/main/java/xyz/gianlu/librespot/spirc/SpotifyIrc.java
+++ b/core/src/main/java/xyz/gianlu/librespot/spirc/SpotifyIrc.java
@@ -91,6 +91,7 @@ public class SpotifyIrc implements Closeable {
                         .setTyp(Spirc.CapabilityType.kSupportedTypes)
                         .addStringValue("audio/local")
                         .addStringValue("audio/track")
+                        .addStringValue("audio/episode")
                         .addStringValue("local")
                         .addStringValue("track")
                         .build());


### PR DESCRIPTION
This should get you started - the load events should reach the client now.
It now crashes with:
```shell
2019-03-30 23:17:02 DEBUG Player:358 - Loading context, uri: spotify:show:09Rlb3I3tzqeI5KRLDTyOb
Exception in thread "handle-packet-1338357277" java.lang.IllegalArgumentException: Not a Spotify track ID: spotify:episode:2seDhYwSEWURmEUYimIxn5
        at xyz.gianlu.librespot.mercury.model.TrackId.fromUri(TrackId.java:32)
        at xyz.gianlu.librespot.player.remote.Remote3Track.id(Remote3Track.java:41)
        at xyz.gianlu.librespot.player.remote.Remote3Track.toTrackRef(Remote3Track.java:36)
        at xyz.gianlu.librespot.player.Player$StateWrapper.update(Player.java:604)
        at xyz.gianlu.librespot.player.Player.updatedTracks(Player.java:269)
        at xyz.gianlu.librespot.player.Player.handleLoad(Player.java:360)
        at xyz.gianlu.librespot.player.Player.handleFrame(Player.java:102)
        at xyz.gianlu.librespot.player.Player.frame(Player.java:193)
        at xyz.gianlu.librespot.spirc.SpotifyIrc$SpircListener.event(SpotifyIrc.java:199)
        at xyz.gianlu.librespot.mercury.MercuryClient$InternalSubListener.dispatch(MercuryClient.java:256)
        at xyz.gianlu.librespot.mercury.MercuryClient.handle(MercuryClient.java:173)
        at xyz.gianlu.librespot.core.PacketsManager$Looper.lambda$run$0(PacketsManager.java:64)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.lang.Thread.run(Unknown Source)
```