### PR TITLE
Update interactive-cli pom.xml

### DIFF
--- a/interactive-cli/pom.xml
+++ b/interactive-cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.gianlu.librespot</groupId>
         <artifactId>librespot-java</artifactId>
-        <version>0.5.2</version>
+        <version>0.6.0</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
I've had the repo cloned for some time and after pulling the last changes "maven clean package" was giving me compile error only for interactive-cli:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project interactive-cli: Compilation failure
[ERROR] /Users/admin/Documents/librespot-java/interactive-cli/src/main/java/xyz/gianlu/librespot/interactivecli/Main.java:[82,33] constructor FileConfiguration in class xyz.gianlu.librespot.FileConfiguration cannot be applied to given types;
[ERROR]   required: java.io.File,java.lang.String[]
[ERROR]   found: java.lang.String[]
[ERROR]   reason: actual and formal argument lists differ in length
```
Which was weird because CI was passing. Right?

Then I looked closer to maven output:
```
[INFO] librespot-java 0.6.0 ............................... SUCCESS [  0.124 s]
[INFO] librespot-java common 0.6.0 ........................ SUCCESS [ 12.953 s]
[INFO] librespot-java core 0.6.0 .......................... SUCCESS [  5.190 s]
[INFO] librespot-java api 0.6.0 ........................... SUCCESS [  2.865 s]
[INFO] librespot-java api client 0.6.0 .................... SUCCESS [  3.634 s]
[INFO] librespot-java interactive CLI 0.5.2 ............... FAILURE [  0.097 s]
```
interactive-cli's clear difference was it's version. Then I looked at the [latest build](https://travis-ci.com/librespot-org/librespot-java/builds/119695439) output and I noticed it's lacking the version:
```
[INFO] librespot-java ..................................... SUCCESS [  7.569 s]
[INFO] librespot-java common .............................. SUCCESS [01:05 min]
[INFO] librespot-java core ................................ SUCCESS [ 15.453 s]
[INFO] librespot-java api ................................. SUCCESS [  7.872 s]
[INFO] librespot-java api client .......................... SUCCESS [ 19.800 s]
[INFO] librespot-java interactive CLI ..................... SUCCESS [06:03 min]
```

So I looked at the source and found out changing the parent version did indeed fix my problem and wanted to shared my thoughts in the form of a PR.
