### PR TITLE
Fix problem regarding using a custom named options file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ target/
 *iml
 config.toml
 /cache/
+.settings/
+.project
+.DS_Store
+bin/
+.classpath
+.vscode/

--- a/core/src/main/java/xyz/gianlu/librespot/FileConfiguration.java
+++ b/core/src/main/java/xyz/gianlu/librespot/FileConfiguration.java
@@ -43,7 +43,7 @@ public final class FileConfiguration extends AbsConfiguration {
         if (override != null) {
             for (String arg : override) {
                 if (arg != null && arg.startsWith("--conf-file="))
-                    confFile = new File(arg.substring(13));
+                    confFile = new File(arg.substring(12));
             }
         }
 

--- a/core/src/main/java/xyz/gianlu/librespot/Version.java
+++ b/core/src/main/java/xyz/gianlu/librespot/Version.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
  * @author Gianlu
  */
 public class Version {
-    public static final String VERSION = "0.5.1";
+    public static final String VERSION = "0.6.1";
 
     @NotNull
     public static String versionString() {


### PR DESCRIPTION
```arg.substring(13)``` should start from index 12. Because "--conf-file=" length is 12, So it occupies index 0 through 11 and everything after is the file name.