### PR TITLE
Zeroconf ApiServer

### DIFF
--- a/api/src/main/java/xyz/gianlu/librespot/api/Main.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/Main.java
@@ -1,8 +1,12 @@
 package xyz.gianlu.librespot.api;
 
+import xyz.gianlu.librespot.AbsConfiguration;
 import xyz.gianlu.librespot.FileConfiguration;
 import xyz.gianlu.librespot.api.server.ApiServer;
+import xyz.gianlu.librespot.api.server.ZeroconfApiServer;
+import xyz.gianlu.librespot.core.AuthConfiguration;
 import xyz.gianlu.librespot.core.Session;
+import xyz.gianlu.librespot.core.ZeroconfServer;
 import xyz.gianlu.librespot.spirc.SpotifyIrc;
 
 import java.io.IOException;
@@ -14,11 +18,19 @@ import java.security.GeneralSecurityException;
 public class Main {
 
     public static void main(String[] args) throws IOException, GeneralSecurityException, SpotifyIrc.IrcException, Session.SpotifyAuthenticationException {
-        Session session = new Session.Builder(new FileConfiguration(args)).create();
+        AbsConfiguration conf = new FileConfiguration(args);
+        if (conf.authStrategy() == AuthConfiguration.Strategy.ZEROCONF) {
+            ZeroconfServer zeroconfServer = ZeroconfServer.create(conf);
 
-        ApiServer server = new ApiServer(24879);
-        server.registerHandler(new PlayerHandler(session));
-        server.registerHandler(new MetadataHandler(session));
-        server.registerHandler(new MercuryHandler(session));
+            ZeroconfApiServer zeroconfApiServer = new ZeroconfApiServer(24879);
+            zeroconfServer.addObserver(zeroconfApiServer);
+        } else {
+            Session session = new Session.Builder(new FileConfiguration(args)).create();
+
+            ApiServer server = new ApiServer(24879);
+            server.registerHandler(new PlayerHandler(session));
+            server.registerHandler(new MetadataHandler(session));
+            server.registerHandler(new MercuryHandler(session));
+        }
     }
 }

--- a/api/src/main/java/xyz/gianlu/librespot/api/Main.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/Main.java
@@ -20,12 +20,9 @@ public class Main {
     public static void main(String[] args) throws IOException, GeneralSecurityException, SpotifyIrc.IrcException, Session.SpotifyAuthenticationException {
         AbsConfiguration conf = new FileConfiguration(args);
         if (conf.authStrategy() == AuthConfiguration.Strategy.ZEROCONF) {
-            ZeroconfServer zeroconfServer = ZeroconfServer.create(conf);
-
-            ZeroconfApiServer zeroconfApiServer = new ZeroconfApiServer(24879);
-            zeroconfServer.addSessionListener(zeroconfApiServer);
+            ZeroconfServer.create(conf).addSessionListener(new ZeroconfApiServer(24879));
         } else {
-            Session session = new Session.Builder(new FileConfiguration(args)).create();
+            Session session = new Session.Builder(conf).create();
 
             ApiServer server = new ApiServer(24879);
             server.registerHandler(new PlayerHandler(session));

--- a/api/src/main/java/xyz/gianlu/librespot/api/Main.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/Main.java
@@ -23,7 +23,7 @@ public class Main {
             ZeroconfServer zeroconfServer = ZeroconfServer.create(conf);
 
             ZeroconfApiServer zeroconfApiServer = new ZeroconfApiServer(24879);
-            zeroconfServer.addObserver(zeroconfApiServer);
+            zeroconfServer.addSessionListener(zeroconfApiServer);
         } else {
             Session session = new Session.Builder(new FileConfiguration(args)).create();
 

--- a/api/src/main/java/xyz/gianlu/librespot/api/server/ApiServer.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/server/ApiServer.java
@@ -64,6 +64,10 @@ public class ApiServer implements Receiver {
         handlers.put(handler.prefix, handler);
     }
 
+    public void clearHandlers() {
+        handlers.clear();
+    }
+
     private void handleRequest(@NotNull Request request) throws PredefinedJsonRpcException {
         int index = request.method.indexOf('.');
         if (index == -1)

--- a/api/src/main/java/xyz/gianlu/librespot/api/server/ZeroconfApiServer.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/server/ZeroconfApiServer.java
@@ -1,5 +1,6 @@
 package xyz.gianlu.librespot.api.server;
 
+import org.apache.log4j.Logger;
 import xyz.gianlu.librespot.api.MercuryHandler;
 import xyz.gianlu.librespot.api.MetadataHandler;
 import xyz.gianlu.librespot.api.PlayerHandler;
@@ -11,6 +12,8 @@ import java.util.Observer;
 
 public class ZeroconfApiServer extends ApiServer implements Observer {
 
+    private static final Logger LOGGER = Logger.getLogger(ZeroconfApiServer.class);
+
     public ZeroconfApiServer(int port) throws IOException {
         super(port);
     }
@@ -19,11 +22,13 @@ public class ZeroconfApiServer extends ApiServer implements Observer {
     public void update(Observable o, Object arg) {
         if (arg instanceof Session) {
             Session session = (Session) arg;
+            LOGGER.info("Got session update, clearing old handlers");
             clearHandlers();
 
             registerHandler(new PlayerHandler(session));
             registerHandler(new MetadataHandler(session));
             registerHandler(new MercuryHandler(session));
+            LOGGER.info("Registered new handlers for session");
         }
     }
 

--- a/api/src/main/java/xyz/gianlu/librespot/api/server/ZeroconfApiServer.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/server/ZeroconfApiServer.java
@@ -8,8 +8,6 @@ import xyz.gianlu.librespot.core.Session;
 import xyz.gianlu.librespot.core.ZeroconfServer;
 
 import java.io.IOException;
-import java.util.Observable;
-import java.util.Observer;
 
 public class ZeroconfApiServer extends ApiServer implements ZeroconfServer.SessionListener {
 

--- a/api/src/main/java/xyz/gianlu/librespot/api/server/ZeroconfApiServer.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/server/ZeroconfApiServer.java
@@ -1,0 +1,30 @@
+package xyz.gianlu.librespot.api.server;
+
+import xyz.gianlu.librespot.api.MercuryHandler;
+import xyz.gianlu.librespot.api.MetadataHandler;
+import xyz.gianlu.librespot.api.PlayerHandler;
+import xyz.gianlu.librespot.core.Session;
+
+import java.io.IOException;
+import java.util.Observable;
+import java.util.Observer;
+
+public class ZeroconfApiServer extends ApiServer implements Observer {
+
+    public ZeroconfApiServer(int port) throws IOException {
+        super(port);
+    }
+
+    @Override
+    public void update(Observable o, Object arg) {
+        if (arg instanceof Session) {
+            Session session = (Session) arg;
+            clearHandlers();
+
+            registerHandler(new PlayerHandler(session));
+            registerHandler(new MetadataHandler(session));
+            registerHandler(new MercuryHandler(session));
+        }
+    }
+
+}

--- a/api/src/main/java/xyz/gianlu/librespot/api/server/ZeroconfApiServer.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/server/ZeroconfApiServer.java
@@ -1,6 +1,7 @@
 package xyz.gianlu.librespot.api.server;
 
 import org.apache.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import xyz.gianlu.librespot.api.MercuryHandler;
 import xyz.gianlu.librespot.api.MetadataHandler;
 import xyz.gianlu.librespot.api.PlayerHandler;
@@ -10,7 +11,6 @@ import xyz.gianlu.librespot.core.ZeroconfServer;
 import java.io.IOException;
 
 public class ZeroconfApiServer extends ApiServer implements ZeroconfServer.SessionListener {
-
     private static final Logger LOGGER = Logger.getLogger(ZeroconfApiServer.class);
 
     public ZeroconfApiServer(int port) throws IOException {
@@ -18,13 +18,12 @@ public class ZeroconfApiServer extends ApiServer implements ZeroconfServer.Sessi
     }
 
     @Override
-    public void sessionChanged(Session session) {
-        LOGGER.info("Got session update, clearing old handlers");
+    public void sessionChanged(@NotNull Session session) {
         clearHandlers();
 
         registerHandler(new PlayerHandler(session));
         registerHandler(new MetadataHandler(session));
         registerHandler(new MercuryHandler(session));
-        LOGGER.info("Registered new handlers for session");
+        LOGGER.info("Refreshed handlers for new session.");
     }
 }

--- a/api/src/main/java/xyz/gianlu/librespot/api/server/ZeroconfApiServer.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/server/ZeroconfApiServer.java
@@ -5,12 +5,13 @@ import xyz.gianlu.librespot.api.MercuryHandler;
 import xyz.gianlu.librespot.api.MetadataHandler;
 import xyz.gianlu.librespot.api.PlayerHandler;
 import xyz.gianlu.librespot.core.Session;
+import xyz.gianlu.librespot.core.ZeroconfServer;
 
 import java.io.IOException;
 import java.util.Observable;
 import java.util.Observer;
 
-public class ZeroconfApiServer extends ApiServer implements Observer {
+public class ZeroconfApiServer extends ApiServer implements ZeroconfServer.SessionListener {
 
     private static final Logger LOGGER = Logger.getLogger(ZeroconfApiServer.class);
 
@@ -19,17 +20,13 @@ public class ZeroconfApiServer extends ApiServer implements Observer {
     }
 
     @Override
-    public void update(Observable o, Object arg) {
-        if (arg instanceof Session) {
-            Session session = (Session) arg;
-            LOGGER.info("Got session update, clearing old handlers");
-            clearHandlers();
+    public void sessionChanged(Session session) {
+        LOGGER.info("Got session update, clearing old handlers");
+        clearHandlers();
 
-            registerHandler(new PlayerHandler(session));
-            registerHandler(new MetadataHandler(session));
-            registerHandler(new MercuryHandler(session));
-            LOGGER.info("Registered new handlers for session");
-        }
+        registerHandler(new PlayerHandler(session));
+        registerHandler(new MetadataHandler(session));
+        registerHandler(new MercuryHandler(session));
+        LOGGER.info("Registered new handlers for session");
     }
-
 }

--- a/core/src/main/java/xyz/gianlu/librespot/core/ZeroconfServer.java
+++ b/core/src/main/java/xyz/gianlu/librespot/core/ZeroconfServer.java
@@ -31,7 +31,7 @@ import java.util.concurrent.Executors;
 /**
  * @author Gianlu
  */
-public class ZeroconfServer implements Closeable {
+public class ZeroconfServer extends Observable implements Closeable {
     public final static int MAX_PORT = 65536;
     public final static int MIN_PORT = 1024;
     private static final Logger LOGGER = Logger.getLogger(ZeroconfServer.class);
@@ -308,6 +308,7 @@ public class ZeroconfServer implements Closeable {
             }
 
             session = Session.from(inner);
+            notifyObservers(session);
             LOGGER.info(String.format("Accepted new user. {deviceId: %s}", session.deviceId()));
 
             session.connect();

--- a/core/src/main/java/xyz/gianlu/librespot/core/ZeroconfServer.java
+++ b/core/src/main/java/xyz/gianlu/librespot/core/ZeroconfServer.java
@@ -308,11 +308,12 @@ public class ZeroconfServer extends Observable implements Closeable {
             }
 
             session = Session.from(inner);
-            notifyObservers(session);
             LOGGER.info(String.format("Accepted new user. {deviceId: %s}", session.deviceId()));
 
             session.connect();
             session.authenticate(credentials);
+            setChanged();
+            notifyObservers(session);
         } catch (Session.SpotifyAuthenticationException | SpotifyIrc.IrcException ex) {
             LOGGER.fatal("Failed handling connection! Going away.", ex);
             close();


### PR DESCRIPTION
I noticed the Zeroconf server couldn't be used with the ApiServer. This PR adds that functionality.

Changes:
- ZeroconfServer now has a interface SessionListener, to notify any listeners for a Session change
- ZeroconfServer now contains a list of SessionListener; notifies listeners when a new Session is authenticated
- Add method ApiServer.clearHandlers(); clears the ApiHandlers Map when a new Session is presented
- Add class ZeroconfApiServer, extends ApiServer implements SessionListener; listens for changes in the ZeroconfServer's Session, clears old request handlers and registers new ones when a new Session is presented