### PR TITLE
Hotfix ZeroconfServer not compiling

### DIFF
--- a/core/src/main/java/xyz/gianlu/librespot/core/ZeroconfServer.java
+++ b/core/src/main/java/xyz/gianlu/librespot/core/ZeroconfServer.java
@@ -419,7 +419,8 @@ public class ZeroconfServer implements Closeable {
                 Map<String, String> params = new HashMap<>(pairs.length);
                 for (String pair : pairs) {
                     String[] split = Utils.split(pair, '=');
-                    params.put(URLDecoder.decode(split[0], StandardCharsets.UTF_8), URLDecoder.decode(split[1], StandardCharsets.UTF_8));
+                    params.put(URLDecoder.decode(split[0], StandardCharsets.UTF_8.name()),
+                            URLDecoder.decode(split[1], StandardCharsets.UTF_8.name()));
                 }
 
                 String action = params.get("action");


### PR DESCRIPTION
ZeroconfServer Doesn't compile with StandardCharsets.UTF_8 in Java 11.
`java: incompatible types: java.nio.charset.Charset cannot be converted to java.lang.String`.

URL parameters should be of String type.