### PR TITLE
Storing the first instance of mixer line and reusing it for next trac…

### DIFF
--- a/core/src/main/java/xyz/gianlu/librespot/player/Player.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/Player.java
@@ -36,6 +36,7 @@ public class Player implements FrameListener, TrackHandler.Listener, Closeable {
     private final LinesHolder lines;
     private TrackHandler trackHandler;
     private TrackHandler preloadTrackHandler;
+    private RpiMixerBypass rpi_mixer_by_pass;
 
     public Player(@NotNull Player.Configuration conf, @NotNull Session session) {
         this.conf = conf;
@@ -43,6 +44,7 @@ public class Player implements FrameListener, TrackHandler.Listener, Closeable {
         this.spirc = session.spirc();
         this.state = new StateWrapper(session);
         this.lines = new LinesHolder();
+        this.rpi_mixer_by_pass = new RpiMixerBypass();
 
         spirc.addListener(this);
     }
@@ -300,7 +302,7 @@ public class Player implements FrameListener, TrackHandler.Listener, Closeable {
         if (handler == trackHandler && state.hasTracks()) {
             PlayableId next = state.nextPlayableDoNotSet();
             if (next != null) {
-                preloadTrackHandler = new TrackHandler(session, lines, conf, this);
+                preloadTrackHandler = new TrackHandler(session, lines, conf, this, rpi_mixer_by_pass);
                 preloadTrackHandler.sendLoad(next, false, 0);
                 LOGGER.trace("Started next track preload, gid: " + Utils.bytesToHex(next.getGid()));
             }
@@ -392,7 +394,7 @@ public class Player implements FrameListener, TrackHandler.Listener, Closeable {
             preloadTrackHandler = null;
             trackHandler.sendSeek(state.getPositionMs());
         } else {
-            trackHandler = new TrackHandler(session, lines, conf, this);
+            trackHandler = new TrackHandler(session, lines, conf, this, rpi_mixer_by_pass);
             trackHandler.sendLoad(id, play, state.getPositionMs());
         }
 

--- a/core/src/main/java/xyz/gianlu/librespot/player/PlayerRunner.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/PlayerRunner.java
@@ -21,10 +21,10 @@ public class PlayerRunner implements Runnable {
     private final Codec codec;
 
     PlayerRunner(@NotNull GeneralAudioStream audioFile, @Nullable NormalizationData normalizationData, @NotNull LinesHolder lines,
-                 @NotNull Player.Configuration conf, @NotNull Listener listener, int duration) throws IOException, Codec.CodecException, LinesHolder.MixerException {
+                 @NotNull Player.Configuration conf, @NotNull Listener listener, int duration, RpiMixerBypass rpi_mixer_bypass) throws IOException, Codec.CodecException, LinesHolder.MixerException {
         switch (audioFile.codec()) {
             case VORBIS:
-                codec = new VorbisCodec(audioFile, normalizationData, conf, listener, lines, duration);
+                codec = new VorbisCodec(audioFile, normalizationData, conf, listener, lines, duration, rpi_mixer_bypass);
                 break;
             case MP3:
                 codec = new Mp3Codec(audioFile, normalizationData, conf, listener, lines, duration);

--- a/core/src/main/java/xyz/gianlu/librespot/player/RpiMixerBypass.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/RpiMixerBypass.java
@@ -1,0 +1,15 @@
+package xyz.gianlu.librespot.player;
+
+public class RpiMixerBypass {
+    private static LinesHolder.LineWrapper backupLine;
+
+    RpiMixerBypass() {
+        backupLine = null;
+    }
+
+    public LinesHolder.LineWrapper getBackupLine() {
+        return backupLine;
+    }
+
+    public void setBackupLine(LinesHolder.LineWrapper inputLine) { backupLine = inputLine; }
+}

--- a/core/src/main/java/xyz/gianlu/librespot/player/TrackHandler.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/TrackHandler.java
@@ -37,14 +37,16 @@ public class TrackHandler implements PlayerRunner.Listener, Closeable, AbsChunck
     private Metadata.Track track;
     private Metadata.Episode episode;
     private PlayerRunner playerRunner;
+    private RpiMixerBypass rpi_mixer_bypass;
     private volatile boolean stopped = false;
     private long haltedAt = -1;
 
-    TrackHandler(@NotNull Session session, @NotNull LinesHolder lines, @NotNull Player.Configuration conf, @NotNull Listener listener) {
+    TrackHandler(@NotNull Session session, @NotNull LinesHolder lines, @NotNull Player.Configuration conf, @NotNull Listener listener, @NotNull RpiMixerBypass rpi_mixer_bypass) {
         this.session = session;
         this.lines = lines;
         this.conf = conf;
         this.listener = listener;
+        this.rpi_mixer_bypass = rpi_mixer_bypass;
 
         Looper looper;
         new Thread(looper = new Looper(), "track-handler-" + looper.hashCode()).start();
@@ -52,7 +54,7 @@ public class TrackHandler implements PlayerRunner.Listener, Closeable, AbsChunck
 
     @NotNull
     private PlayerRunner createRunner(@NotNull BaseFeeder.LoadedStream stream) throws Codec.CodecException, IOException, LinesHolder.MixerException {
-        return new PlayerRunner(stream.in, stream.normalizationData, lines, conf, this, track == null ? episode.getDuration() : track.getDuration());
+        return new PlayerRunner(stream.in, stream.normalizationData, lines, conf, this, track == null ? episode.getDuration() : track.getDuration(), rpi_mixer_bypass);
     }
 
     private void load(@NotNull PlayableId id, boolean play, int pos) throws IOException, MercuryClient.MercuryException, CdnManager.CdnException, ContentRestrictedException {


### PR DESCRIPTION
…ks instead of obtaining new instance (which fails on Raspberry Pi due to ASoc sound subsystem limitations, see https://support.hifiberry.com/hc/en-us/articles/207397665-Mixing-different-audio-sources )