### PR TITLE
adds CorsHeaders to allow usage from javascript

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -56,5 +56,10 @@
             <artifactId>undertow-core</artifactId>
             <version>2.0.27.Final</version>
         </dependency>
+        <dependency>
+            <groupId>com.stijndewitt.undertow.cors</groupId>
+            <artifactId>undertow-cors-filter</artifactId>
+            <version>0.4.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/api/src/main/java/xyz/gianlu/librespot/api/ApiServer.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/ApiServer.java
@@ -1,5 +1,7 @@
 package xyz.gianlu.librespot.api;
 
+import com.stijndewitt.undertow.cors.AllowAll;
+import com.stijndewitt.undertow.cors.Filter;
 import io.undertow.Undertow;
 import io.undertow.server.RoutingHandler;
 import org.apache.log4j.Logger;
@@ -32,7 +34,12 @@ public class ApiServer {
         RoutingHandler handler = new RoutingHandler();
         prepareHandlers(handler, session);
 
-        undertow = Undertow.builder().addHttpListener(port, "", handler).build();
+        Filter corsFilter = new Filter(handler);
+        corsFilter.setPolicyClass(AllowAll.class.getCanonicalName());
+        corsFilter.setPolicyParam(null);
+        corsFilter.setUrlPattern(".*");
+
+        undertow = Undertow.builder().addHttpListener(port, "", corsFilter).build();
         undertow.start();
         LOGGER.info(String.format("Server started on port %d!", port));
     }


### PR DESCRIPTION
This adds CORS Headers to allow usage from browser based web apps:

**without** header *Origin*
```
$ curl -XPOST 'http://localhost:24879/metadata/track/spotify:track:4lXt6ROo0I3U7p3loYQX5U' -v | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:24879...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 24879 (#0)
> POST /metadata/track/spotify:track:4lXt6ROo0I3U7p3loYQX5U HTTP/1.1
> Host: localhost:24879
> User-Agent: curl/7.66.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Connection: keep-alive
< Content-Length: 1457
< Date: Mon, 16 Dec 2019 00:07:06 GMT
```

**with** header *Origin* 
```
$ curl -XPOST -H 'Origin:localhost' 'http://localhost:24879/metadata/track/spotify:track:4lXt6ROo0I3U7p3loYQX5U' -v | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:24879...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 24879 (#0)
> POST /metadata/track/spotify:track:4lXt6ROo0I3U7p3loYQX5U HTTP/1.1
> Host: localhost:24879
> User-Agent: curl/7.66.0
> Accept: */*
> Origin:localhost
> 
  0     0    0     0    0     0      0      0 --:--:--  0:00:18 --:--:--     0* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Access-Control-Allow-Headers: Authorization,Content-Type,Link,X-Total-Count,Range
< Access-Control-Expose-Headers: Accept-Ranges,Content-Length,Content-Range,ETag,Link,Server,X-Total-Count
< Date: Sun, 15 Dec 2019 23:58:52 GMT
< Connection: keep-alive
< Access-Control-Allow-Origin: localhost
< Access-Control-Allow-Credentials: true
< Content-Length: 1457
< Access-Control-Allow-Methods: DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT
< Access-Control-Max-Age: 864000
< 

```

implementation is based on https://stackoverflow.com/questions/42066845/how-to-enable-access-control-allow-origin-in-undertow