### PR TITLE
Free accounts support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Its main features are:
 - Zeroconf (Spotify Connect)
 - Gapless playback
 - Mixed playlists (cuepoints and transitions)
+- Free accounts support
 
 ## Get started
 All the configuration you need is inside the `config.toml` file, there you can decide to authenticate with:


### PR DESCRIPTION
Looking forward to implement a ToS compliant support for free accounts. Previous discussion: https://github.com/librespot-org/librespot/issues/415 and https://github.com/librespot-org/librespot/issues/261.

**I'd like to remember that any use of free accounts until this PR is merged is not supported by the team.**