### PR TITLE
Make device id configurable

### DIFF
--- a/common/src/main/java/xyz/gianlu/librespot/common/Utils.java
+++ b/common/src/main/java/xyz/gianlu/librespot/common/Utils.java
@@ -35,6 +35,13 @@ public final class Utils {
     }
 
     @NotNull
+    public static String randomHexString(@NotNull Random random, int length) {
+        byte[] bytes = new byte[length / 2];
+        random.nextBytes(bytes);
+        return bytesToHex(bytes, 0, bytes.length, false, length);
+    }
+
+    @NotNull
     public static String randomString(@NotNull Random random, int length) {
         char[] chars = new char[length];
         for (int i = 0; i < length; i++)

--- a/core/src/main/java/xyz/gianlu/librespot/AbsConfiguration.java
+++ b/core/src/main/java/xyz/gianlu/librespot/AbsConfiguration.java
@@ -18,6 +18,9 @@ import xyz.gianlu.librespot.player.Player;
 public abstract class AbsConfiguration implements ApiConfiguration, Session.ProxyConfiguration, TimeProvider.Configuration, Player.Configuration, CacheManager.Configuration, AuthConfiguration, ZeroconfServer.Configuration {
 
     @Nullable
+    public abstract String deviceId();
+
+    @Nullable
     public abstract String deviceName();
 
     @Nullable

--- a/core/src/main/java/xyz/gianlu/librespot/FileConfiguration.java
+++ b/core/src/main/java/xyz/gianlu/librespot/FileConfiguration.java
@@ -305,6 +305,11 @@ public final class FileConfiguration extends AbsConfiguration {
     }
 
     @Override
+    public @Nullable String deviceId() {
+        return config.get("deviceId");
+    }
+
+    @Override
     public @Nullable String deviceName() {
         return config.get("deviceName");
     }

--- a/core/src/main/java/xyz/gianlu/librespot/core/Session.java
+++ b/core/src/main/java/xyz/gianlu/librespot/core/Session.java
@@ -649,7 +649,9 @@ public final class Session implements Closeable {
             this.deviceName = deviceName;
             this.configuration = configuration;
             this.random = new SecureRandom();
-            this.deviceId = Utils.randomString(random, 40);
+
+            final String configuredDeviceId = configuration.deviceId();
+            this.deviceId = (configuredDeviceId == null || configuredDeviceId.isEmpty()) ? Utils.randomString(random, 40) : configuredDeviceId;
         }
 
         @NotNull
@@ -784,6 +786,7 @@ public final class Session implements Closeable {
                             facebook();
                             break;
                         case BLOB:
+                            if(!inner.deviceId.equals(inner.configuration.deviceId())) throw new IllegalArgumentException("Missing deviceId! Must not be empty when using " + authConf.authStrategy());
                             if (username == null) throw new IllegalArgumentException("Missing authUsername!");
                             if (blob == null) throw new IllegalArgumentException("Missing authBlob!");
                             blob(username, Base64.getDecoder().decode(blob));

--- a/core/src/main/java/xyz/gianlu/librespot/core/Session.java
+++ b/core/src/main/java/xyz/gianlu/librespot/core/Session.java
@@ -668,8 +668,9 @@ public final class Session implements Closeable {
             this.configuration = configuration;
             this.random = new SecureRandom();
 
-            final String configuredDeviceId = configuration.deviceId();
-            this.deviceId = (configuredDeviceId == null || configuredDeviceId.isEmpty()) ? Utils.randomString(random, 40) : configuredDeviceId;
+            String configuredDeviceId = configuration.deviceId();
+            this.deviceId = (configuredDeviceId == null || configuredDeviceId.isEmpty()) ?
+                    Utils.randomHexString(random, 40).toLowerCase() : configuredDeviceId;
         }
 
         @NotNull

--- a/core/src/main/resources/default.toml
+++ b/core/src/main/resources/default.toml
@@ -1,3 +1,4 @@
+deviceId = "" ### Device Id (40 chars)  ###
 deviceName = "librespot-java" ### Device name ###
 deviceType = "COMPUTER" ### Device type (COMPUTER, TABLET, SMARTPHONE, SPEAKER, TV, AVR, STB, AUDIO_DONGLE, GAME_CONSOLE, CAST_VIDEO, CAST_AUDIO, AUTOMOBILE, WEARABLE, UNKNOWN_SPOTIFY, CAR_THING, UNKNOWN) ###
 preferredLocale = "en" ### Preferred locale ###

--- a/core/src/main/resources/default.toml
+++ b/core/src/main/resources/default.toml
@@ -1,4 +1,4 @@
-deviceId = "" ### Device Id (40 chars)  ###
+deviceId = "" ### Device ID (40 chars, leave empty for random)  ###
 deviceName = "librespot-java" ### Device name ###
 deviceType = "COMPUTER" ### Device type (COMPUTER, TABLET, SMARTPHONE, SPEAKER, TV, AVR, STB, AUDIO_DONGLE, GAME_CONSOLE, CAST_VIDEO, CAST_AUDIO, AUTOMOBILE, WEARABLE, UNKNOWN_SPOTIFY, CAR_THING, UNKNOWN) ###
 preferredLocale = "en" ### Preferred locale ###


### PR DESCRIPTION
In my situation, I create multiple instances of librespot-java and each instance can randomly appear & disappear. 

To avoid confusion with the deviceId's (mdns), I have to set a persistent deviceId for each instance so an instance doesn't appear twice with the same name and different deviceId.

Please allow to set a permantent deviceId.