### PR TITLE
Runtime init of metadata pipe and threaded send

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: java
 os: linux
 
 before_install:
-  - [ "${TRAVIS_PULL_REQUEST}" = "false" ] && echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import
-  - [ "${TRAVIS_PULL_REQUEST}" = "false" ] && echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust
+  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import'
+  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust'
 
 script:
   - mvn clean test -Pdebug -B -U -Dgpg.skip -Dmaven.javadoc.skip=true
 
 after_script:
-  - [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${$TRAVIS_BRANCH}" = "dev" ] && mvn deploy --settings .maven.xml -B -U -Prelease
+  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${$TRAVIS_BRANCH}" = "dev" ] && mvn deploy --settings .maven.xml -B -U -Prelease'
 
 before_deploy:
   - mvn help:evaluate -N -Dexpression=project.version|grep -v '\['

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 os: linux
 
 before_install:
-  - chmod +x .travis/*'
+  - chmod +x .travis/*
   - .travis/before_install.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: java
 os: linux
 
 before_install:
-  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import'
-  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust'
+  - chmod +x .travis/*'
+  - .travis/before_install.sh
 
 script:
   - mvn clean test -Pdebug -B -U -Dgpg.skip -Dmaven.javadoc.skip=true
 
 after_script:
-  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${$TRAVIS_BRANCH}" = "dev" ] && mvn deploy --settings .maven.xml -B -U -Prelease'
+  - .travis/after_script.sh
 
 before_deploy:
   - mvn help:evaluate -N -Dexpression=project.version|grep -v '\['

--- a/.travis/after_script.sh
+++ b/.travis/after_script.sh
@@ -1,0 +1,3 @@
+if ( [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${$TRAVIS_BRANCH}" = "dev" ] ) then;
+  mvn deploy --settings .maven.xml -B -U -Prelease
+fi

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,0 +1,4 @@
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+  echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import
+  echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust
+fi


### PR DESCRIPTION
When using forked-daapd with autostart, the forked-daapd server watches the audio named pipe but doesn't seem to open the metadata pipe until the audio pipe starts playing. Since there is no reader on the metadata named pipe, the librespot-java client blocks on creating the FileOutputStream in the metadataPipe constructor. Initializing the pipe before sending takes care of this.
Moved the sending to threads primarily for the sendImage method as it involves web access.