### PR TITLE
adds build with multiple jdks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,13 @@ deploy:
       - api/target/librespot-api-sources.jar
     on:
       repo: librespot-org/librespot-java
+      jdk: 'openjdk11'
       tags: true
   - provider: script
     script: mvn deploy --settings .maven.xml -B -U -Prelease
     on:
       repo: librespot-org/librespot-java
+      jdk: 'openjdk11'
       all_branches: true
       condition: $TRAVIS_BRANCH = "master" || $TRAVIS_BRANCH = "dev"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 os: linux
+jdk:
+  - openjdk8
+  - openjdk11
+  - openjdk13
 
 before_install:
   - chmod +x .travis/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os: linux
 
 before_install:
   - chmod +x .travis/*
-  - .travis/before_install.sh
 
 script:
   - mvn clean test -Pdebug -B -U -Dgpg.skip -Dmaven.javadoc.skip=true
@@ -12,6 +11,7 @@ after_script:
   - .travis/after_script.sh
 
 before_deploy:
+  - .travis/before_install.sh
   - mvn package -B -U -Prelease
   - mvn help:evaluate -N -Dexpression=project.version|grep -v '\['
   - export project_version=$(mvn help:evaluate -N -Dexpression=project.version|grep -v '\[')


### PR DESCRIPTION
depends on #190

The build runs implicitely with openjdk11. [job](https://travis-ci.com/github/librespot-org/librespot-java/jobs/300254434#L202)

For better build stability this adds runs with multiple jdks: 8, 11 + latest available (13).

This could allow a smooth transition to newer version of java in the future.