### PR TITLE
Send metadata when resuming

### DIFF
--- a/core/src/main/java/xyz/gianlu/librespot/player/Player.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/Player.java
@@ -902,6 +902,13 @@ public class Player implements Closeable, DeviceStateHandler.Listener, PlayerRun
             long trackTime = state.getPosition();
             for (EventsListener l : new ArrayList<>(listeners))
                 executorService.execute(() -> l.onPlaybackResumed(trackTime));
+            if (metadataPipe.enabled()) {
+                executorService.execute(() -> {
+                    sendTrackInfo();
+                    sendProgress();
+                    sendImage();
+                });
+            }
         }
 
         void contextChanged() {


### PR DESCRIPTION
If the player is paused mid song while the pipe receiver changes context or reboots, the pipe receiver might forget what is playing. Sending the metadata again when resuming would take care of this.