### PR TITLE
Changed logging to include milliseconds by default.

### DIFF
--- a/api/src/main/resources/log4j.properties
+++ b/api/src/main/resources/log4j.properties
@@ -2,7 +2,7 @@ log4j.rootLogger=TRACE, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d %-5p %c{1}:%L - %m%n
 # Mute Undertow and its dependencies
 log4j.logger.io.undertow=WARN
 log4j.logger.org.jboss=WARN

--- a/core/src/main/resources/log4j.properties
+++ b/core/src/main/resources/log4j.properties
@@ -2,4 +2,4 @@ log4j.rootLogger=TRACE, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
Output now looks like:

```
2020-04-12 21:04:58,164 INFO  Utils:108 - Successfully removed cryptography restrictions.
2020-04-12 21:04:58,430 INFO  ApResolver:66 - Loaded aps into pool: {accesspoint=[guc3-accesspoint-b-6ts2.ap.spotify.com:4070, guc3-accesspoint-b-7d3h.ap.spotify.com:443, guc3-accesspoint-b-wr96.ap.spotify.com:80, guc3-accesspoint-b-slqh.ap.spotify.com:4070, guc3-accesspoint-b-jw6w.ap.spotify.com:443, guc3-accesspoint-b-bknf.ap.spotify.com:80, gae2-accesspoint-b-0fvt.ap.spotify.com:4070, gew1-accesspoint-b-dmwz.ap.spotify.com:443, gew1-accesspoint-b-czzt.ap.spotify.com:80], dealer=[guc-dealer.spotify.com:443, gae-dealer.spotify.com:443, gew-dealer.spotify.com:443], spclient=[guc-spclient.spotify.com:443, gew-spclient.spotify.com:443, gae-spclient.spotify.com:443]}
2020-04-12 21:04:58,470 INFO  ZeroconfServer:369 - Zeroconf HTTP server started successfully on port 52331!
```

which makes debugging playback issues easier.