### PR TITLE
Stop threads on session close

### DIFF
--- a/core/src/main/java/xyz/gianlu/librespot/core/PacketsManager.java
+++ b/core/src/main/java/xyz/gianlu/librespot/core/PacketsManager.java
@@ -1,6 +1,5 @@
 package xyz.gianlu.librespot.core;
 
-import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import xyz.gianlu.librespot.crypto.Packet;
 
@@ -13,7 +12,6 @@ import java.util.concurrent.LinkedBlockingQueue;
  * @author Gianlu
  */
 public abstract class PacketsManager implements AutoCloseable {
-    private static final Logger LOGGER = Logger.getLogger(PacketsManager.class);
     protected final Session session;
     private final BlockingQueue<Packet> queue;
     private final Looper looper;
@@ -49,12 +47,9 @@ public abstract class PacketsManager implements AutoCloseable {
 
     private final class Looper implements Runnable {
         private volatile boolean shouldStop = false;
-        private Thread thread;
 
         @Override
         public void run() {
-            LOGGER.trace("PacketsManager.Looper started");
-            this.thread = Thread.currentThread();
             while (!shouldStop) {
                 try {
                     Packet packet = queue.take();
@@ -68,12 +63,10 @@ public abstract class PacketsManager implements AutoCloseable {
                 } catch (InterruptedException ignored) {
                 }
             }
-            LOGGER.trace("PacketsManager.Looper stopped");
         }
 
         void stop() {
             shouldStop = true;
-            thread.interrupt();
         }
     }
 }

--- a/core/src/main/java/xyz/gianlu/librespot/core/PacketsManager.java
+++ b/core/src/main/java/xyz/gianlu/librespot/core/PacketsManager.java
@@ -1,5 +1,6 @@
 package xyz.gianlu.librespot.core;
 
+import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import xyz.gianlu.librespot.crypto.Packet;
 
@@ -12,6 +13,7 @@ import java.util.concurrent.LinkedBlockingQueue;
  * @author Gianlu
  */
 public abstract class PacketsManager implements AutoCloseable {
+	private static final Logger LOGGER = Logger.getLogger(PacketsManager.class);
     protected final Session session;
     private final BlockingQueue<Packet> queue;
     private final Looper looper;
@@ -47,9 +49,12 @@ public abstract class PacketsManager implements AutoCloseable {
 
     private final class Looper implements Runnable {
         private volatile boolean shouldStop = false;
+		private Thread thread;
 
         @Override
         public void run() {
+			LOGGER.trace("PacketsManager.Looper started");
+			this.thread = Thread.currentThread();
             while (!shouldStop) {
                 try {
                     Packet packet = queue.take();
@@ -63,10 +68,12 @@ public abstract class PacketsManager implements AutoCloseable {
                 } catch (InterruptedException ignored) {
                 }
             }
+			LOGGER.trace("PacketsManager.Looper stopped");
         }
 
         void stop() {
             shouldStop = true;
+			thread.interrupt();
         }
     }
 }

--- a/core/src/main/java/xyz/gianlu/librespot/core/PacketsManager.java
+++ b/core/src/main/java/xyz/gianlu/librespot/core/PacketsManager.java
@@ -13,67 +13,67 @@ import java.util.concurrent.LinkedBlockingQueue;
  * @author Gianlu
  */
 public abstract class PacketsManager implements AutoCloseable {
-	private static final Logger LOGGER = Logger.getLogger(PacketsManager.class);
-	protected final Session session;
-	private final BlockingQueue<Packet> queue;
-	private final Looper looper;
-	private final ExecutorService executorService;
+    private static final Logger LOGGER = Logger.getLogger(PacketsManager.class);
+    protected final Session session;
+    private final BlockingQueue<Packet> queue;
+    private final Looper looper;
+    private final ExecutorService executorService;
 
-	public PacketsManager(@NotNull Session session) {
-		this.session = session;
-		this.executorService = session.executor();
-		this.queue = new LinkedBlockingQueue<>();
-		this.looper = new Looper();
-		new Thread(looper, "packets-manager-" + looper.hashCode()).start();
-	}
+    public PacketsManager(@NotNull Session session) {
+        this.session = session;
+        this.executorService = session.executor();
+        this.queue = new LinkedBlockingQueue<>();
+        this.looper = new Looper();
+        new Thread(looper, "packets-manager-" + looper.hashCode()).start();
+    }
 
-	public final void dispatch(@NotNull Packet packet) {
-		appendToQueue(packet);
-	}
+    public final void dispatch(@NotNull Packet packet) {
+        appendToQueue(packet);
+    }
 
-	@Override
-	public void close() {
-		looper.stop();
-	}
+    @Override
+    public void close() {
+        looper.stop();
+    }
 
-	/**
-	 * This method can be overridden to process packet synchronously. This MUST not block for a long period of time.
-	 */
-	protected void appendToQueue(@NotNull Packet packet) {
-		queue.add(packet);
-	}
+    /**
+     * This method can be overridden to process packet synchronously. This MUST not block for a long period of time.
+     */
+    protected void appendToQueue(@NotNull Packet packet) {
+        queue.add(packet);
+    }
 
-	protected abstract void handle(@NotNull Packet packet) throws IOException;
+    protected abstract void handle(@NotNull Packet packet) throws IOException;
 
-	protected abstract void exception(@NotNull Exception ex);
+    protected abstract void exception(@NotNull Exception ex);
 
-	private final class Looper implements Runnable {
-		private volatile boolean shouldStop = false;
-		private Thread thread;
+    private final class Looper implements Runnable {
+        private volatile boolean shouldStop = false;
+        private Thread thread;
 
-		@Override
-		public void run() {
-			LOGGER.trace("PacketsManager.Looper started");
-			this.thread = Thread.currentThread();
-			while (!shouldStop) {
-				try {
-					Packet packet = queue.take();
-					executorService.execute(() -> {
-						try {
-							handle(packet);
-						} catch (IOException ex) {
-							exception(ex);
-						}
-					});
-				} catch (InterruptedException ignored) {
-				}
-			}
-			LOGGER.trace("PacketsManager.Looper stopped");
-		}
+        @Override
+        public void run() {
+            LOGGER.trace("PacketsManager.Looper started");
+            this.thread = Thread.currentThread();
+            while (!shouldStop) {
+                try {
+                    Packet packet = queue.take();
+                    executorService.execute(() -> {
+                        try {
+                            handle(packet);
+                        } catch (IOException ex) {
+                            exception(ex);
+                        }
+                    });
+                } catch (InterruptedException ignored) {
+                }
+            }
+            LOGGER.trace("PacketsManager.Looper stopped");
+        }
 
-		void stop() {
-			shouldStop = true;
-			thread.interrupt();
-		}
-	}
+        void stop() {
+            shouldStop = true;
+            thread.interrupt();
+        }
+    }
 }

--- a/core/src/main/java/xyz/gianlu/librespot/core/Session.java
+++ b/core/src/main/java/xyz/gianlu/librespot/core/Session.java
@@ -57,383 +57,383 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @author Gianlu
  */
 public final class Session implements Closeable, SubListener {
-	private static final Logger LOGGER = Logger.getLogger(Session.class);
-	private static final byte[] serverKey = new byte[] {(byte) 0xac, (byte) 0xe0, (byte) 0x46, (byte) 0x0b, (byte) 0xff, (byte) 0xc2, (byte) 0x30, (byte) 0xaf, (byte) 0xf4, (byte) 0x6b,
-			(byte) 0xfe, (byte) 0xc3, (byte) 0xbf, (byte) 0xbf, (byte) 0x86, (byte) 0x3d, (byte) 0xa1, (byte) 0x91, (byte) 0xc6, (byte) 0xcc, (byte) 0x33, (byte) 0x6c, (byte) 0x93,
-			(byte) 0xa1, (byte) 0x4f, (byte) 0xb3, (byte) 0xb0, (byte) 0x16, (byte) 0x12, (byte) 0xac, (byte) 0xac, (byte) 0x6a, (byte) 0xf1, (byte) 0x80, (byte) 0xe7, (byte) 0xf6,
-			(byte) 0x14, (byte) 0xd9, (byte) 0x42, (byte) 0x9d, (byte) 0xbe, (byte) 0x2e, (byte) 0x34, (byte) 0x66, (byte) 0x43, (byte) 0xe3, (byte) 0x62, (byte) 0xd2, (byte) 0x32,
-			(byte) 0x7a, (byte) 0x1a, (byte) 0x0d, (byte) 0x92, (byte) 0x3b, (byte) 0xae, (byte) 0xdd, (byte) 0x14, (byte) 0x02, (byte) 0xb1, (byte) 0x81, (byte) 0x55, (byte) 0x05,
-			(byte) 0x61, (byte) 0x04, (byte) 0xd5, (byte) 0x2c, (byte) 0x96, (byte) 0xa4, (byte) 0x4c, (byte) 0x1e, (byte) 0xcc, (byte) 0x02, (byte) 0x4a, (byte) 0xd4, (byte) 0xb2,
-			(byte) 0x0c, (byte) 0x00, (byte) 0x1f, (byte) 0x17, (byte) 0xed, (byte) 0xc2, (byte) 0x2f, (byte) 0xc4, (byte) 0x35, (byte) 0x21, (byte) 0xc8, (byte) 0xf0, (byte) 0xcb,
-			(byte) 0xae, (byte) 0xd2, (byte) 0xad, (byte) 0xd7, (byte) 0x2b, (byte) 0x0f, (byte) 0x9d, (byte) 0xb3, (byte) 0xc5, (byte) 0x32, (byte) 0x1a, (byte) 0x2a, (byte) 0xfe,
-			(byte) 0x59, (byte) 0xf3, (byte) 0x5a, (byte) 0x0d, (byte) 0xac, (byte) 0x68, (byte) 0xf1, (byte) 0xfa, (byte) 0x62, (byte) 0x1e, (byte) 0xfb, (byte) 0x2c, (byte) 0x8d,
-			(byte) 0x0c, (byte) 0xb7, (byte) 0x39, (byte) 0x2d, (byte) 0x92, (byte) 0x47, (byte) 0xe3, (byte) 0xd7, (byte) 0x35, (byte) 0x1a, (byte) 0x6d, (byte) 0xbd, (byte) 0x24,
-			(byte) 0xc2, (byte) 0xae, (byte) 0x25, (byte) 0x5b, (byte) 0x88, (byte) 0xff, (byte) 0xab, (byte) 0x73, (byte) 0x29, (byte) 0x8a, (byte) 0x0b, (byte) 0xcc, (byte) 0xcd,
-			(byte) 0x0c, (byte) 0x58, (byte) 0x67, (byte) 0x31, (byte) 0x89, (byte) 0xe8, (byte) 0xbd, (byte) 0x34, (byte) 0x80, (byte) 0x78, (byte) 0x4a, (byte) 0x5f, (byte) 0xc9,
-			(byte) 0x6b, (byte) 0x89, (byte) 0x9d, (byte) 0x95, (byte) 0x6b, (byte) 0xfc, (byte) 0x86, (byte) 0xd7, (byte) 0x4f, (byte) 0x33, (byte) 0xa6, (byte) 0x78, (byte) 0x17,
-			(byte) 0x96, (byte) 0xc9, (byte) 0xc3, (byte) 0x2d, (byte) 0x0d, (byte) 0x32, (byte) 0xa5, (byte) 0xab, (byte) 0xcd, (byte) 0x05, (byte) 0x27, (byte) 0xe2, (byte) 0xf7,
-			(byte) 0x10, (byte) 0xa3, (byte) 0x96, (byte) 0x13, (byte) 0xc4, (byte) 0x2f, (byte) 0x99, (byte) 0xc0, (byte) 0x27, (byte) 0xbf, (byte) 0xed, (byte) 0x04, (byte) 0x9c,
-			(byte) 0x3c, (byte) 0x27, (byte) 0x58, (byte) 0x04, (byte) 0xb6, (byte) 0xb2, (byte) 0x19, (byte) 0xf9, (byte) 0xc1, (byte) 0x2f, (byte) 0x02, (byte) 0xe9, (byte) 0x48,
-			(byte) 0x63, (byte) 0xec, (byte) 0xa1, (byte) 0xb6, (byte) 0x42, (byte) 0xa0, (byte) 0x9d, (byte) 0x48, (byte) 0x25, (byte) 0xf8, (byte) 0xb3, (byte) 0x9d, (byte) 0xd0,
-			(byte) 0xe8, (byte) 0x6a, (byte) 0xf9, (byte) 0x48, (byte) 0x4d, (byte) 0xa1, (byte) 0xc2, (byte) 0xba, (byte) 0x86, (byte) 0x30, (byte) 0x42, (byte) 0xea, (byte) 0x9d,
-			(byte) 0xb3, (byte) 0x08, (byte) 0x6c, (byte) 0x19, (byte) 0x0e, (byte) 0x48, (byte) 0xb3, (byte) 0x9d, (byte) 0x66, (byte) 0xeb, (byte) 0x00, (byte) 0x06, (byte) 0xa2,
-			(byte) 0x5a, (byte) 0xee, (byte) 0xa1, (byte) 0x1b, (byte) 0x13, (byte) 0x87, (byte) 0x3c, (byte) 0xd7, (byte) 0x19, (byte) 0xe6, (byte) 0x55, (byte) 0xbd};
-	private final DiffieHellman keys;
-	private final Inner inner;
-	private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(new NameThreadFactory(r -> "session-scheduler-" + r.hashCode()));
-	private final ExecutorService executorService = Executors.newCachedThreadPool(new NameThreadFactory(r -> "handle-packet-" + r.hashCode()));
-	private final AtomicBoolean authLock = new AtomicBoolean(false);
-	private final OkHttpClient client;
-	private final List<CloseListener> closeListeners = Collections.synchronizedList(new ArrayList<>());
-	private final List<ReconnectionListener> reconnectionListeners = Collections.synchronizedList(new ArrayList<>());
+    private static final Logger LOGGER = Logger.getLogger(Session.class);
+    private static final byte[] serverKey = new byte[]{(byte) 0xac, (byte) 0xe0, (byte) 0x46, (byte) 0x0b, (byte) 0xff, (byte) 0xc2, (byte) 0x30, (byte) 0xaf, (byte) 0xf4, (byte) 0x6b,
+            (byte) 0xfe, (byte) 0xc3, (byte) 0xbf, (byte) 0xbf, (byte) 0x86, (byte) 0x3d, (byte) 0xa1, (byte) 0x91, (byte) 0xc6, (byte) 0xcc, (byte) 0x33, (byte) 0x6c, (byte) 0x93,
+            (byte) 0xa1, (byte) 0x4f, (byte) 0xb3, (byte) 0xb0, (byte) 0x16, (byte) 0x12, (byte) 0xac, (byte) 0xac, (byte) 0x6a, (byte) 0xf1, (byte) 0x80, (byte) 0xe7, (byte) 0xf6,
+            (byte) 0x14, (byte) 0xd9, (byte) 0x42, (byte) 0x9d, (byte) 0xbe, (byte) 0x2e, (byte) 0x34, (byte) 0x66, (byte) 0x43, (byte) 0xe3, (byte) 0x62, (byte) 0xd2, (byte) 0x32,
+            (byte) 0x7a, (byte) 0x1a, (byte) 0x0d, (byte) 0x92, (byte) 0x3b, (byte) 0xae, (byte) 0xdd, (byte) 0x14, (byte) 0x02, (byte) 0xb1, (byte) 0x81, (byte) 0x55, (byte) 0x05,
+            (byte) 0x61, (byte) 0x04, (byte) 0xd5, (byte) 0x2c, (byte) 0x96, (byte) 0xa4, (byte) 0x4c, (byte) 0x1e, (byte) 0xcc, (byte) 0x02, (byte) 0x4a, (byte) 0xd4, (byte) 0xb2,
+            (byte) 0x0c, (byte) 0x00, (byte) 0x1f, (byte) 0x17, (byte) 0xed, (byte) 0xc2, (byte) 0x2f, (byte) 0xc4, (byte) 0x35, (byte) 0x21, (byte) 0xc8, (byte) 0xf0, (byte) 0xcb,
+            (byte) 0xae, (byte) 0xd2, (byte) 0xad, (byte) 0xd7, (byte) 0x2b, (byte) 0x0f, (byte) 0x9d, (byte) 0xb3, (byte) 0xc5, (byte) 0x32, (byte) 0x1a, (byte) 0x2a, (byte) 0xfe,
+            (byte) 0x59, (byte) 0xf3, (byte) 0x5a, (byte) 0x0d, (byte) 0xac, (byte) 0x68, (byte) 0xf1, (byte) 0xfa, (byte) 0x62, (byte) 0x1e, (byte) 0xfb, (byte) 0x2c, (byte) 0x8d,
+            (byte) 0x0c, (byte) 0xb7, (byte) 0x39, (byte) 0x2d, (byte) 0x92, (byte) 0x47, (byte) 0xe3, (byte) 0xd7, (byte) 0x35, (byte) 0x1a, (byte) 0x6d, (byte) 0xbd, (byte) 0x24,
+            (byte) 0xc2, (byte) 0xae, (byte) 0x25, (byte) 0x5b, (byte) 0x88, (byte) 0xff, (byte) 0xab, (byte) 0x73, (byte) 0x29, (byte) 0x8a, (byte) 0x0b, (byte) 0xcc, (byte) 0xcd,
+            (byte) 0x0c, (byte) 0x58, (byte) 0x67, (byte) 0x31, (byte) 0x89, (byte) 0xe8, (byte) 0xbd, (byte) 0x34, (byte) 0x80, (byte) 0x78, (byte) 0x4a, (byte) 0x5f, (byte) 0xc9,
+            (byte) 0x6b, (byte) 0x89, (byte) 0x9d, (byte) 0x95, (byte) 0x6b, (byte) 0xfc, (byte) 0x86, (byte) 0xd7, (byte) 0x4f, (byte) 0x33, (byte) 0xa6, (byte) 0x78, (byte) 0x17,
+            (byte) 0x96, (byte) 0xc9, (byte) 0xc3, (byte) 0x2d, (byte) 0x0d, (byte) 0x32, (byte) 0xa5, (byte) 0xab, (byte) 0xcd, (byte) 0x05, (byte) 0x27, (byte) 0xe2, (byte) 0xf7,
+            (byte) 0x10, (byte) 0xa3, (byte) 0x96, (byte) 0x13, (byte) 0xc4, (byte) 0x2f, (byte) 0x99, (byte) 0xc0, (byte) 0x27, (byte) 0xbf, (byte) 0xed, (byte) 0x04, (byte) 0x9c,
+            (byte) 0x3c, (byte) 0x27, (byte) 0x58, (byte) 0x04, (byte) 0xb6, (byte) 0xb2, (byte) 0x19, (byte) 0xf9, (byte) 0xc1, (byte) 0x2f, (byte) 0x02, (byte) 0xe9, (byte) 0x48,
+            (byte) 0x63, (byte) 0xec, (byte) 0xa1, (byte) 0xb6, (byte) 0x42, (byte) 0xa0, (byte) 0x9d, (byte) 0x48, (byte) 0x25, (byte) 0xf8, (byte) 0xb3, (byte) 0x9d, (byte) 0xd0,
+            (byte) 0xe8, (byte) 0x6a, (byte) 0xf9, (byte) 0x48, (byte) 0x4d, (byte) 0xa1, (byte) 0xc2, (byte) 0xba, (byte) 0x86, (byte) 0x30, (byte) 0x42, (byte) 0xea, (byte) 0x9d,
+            (byte) 0xb3, (byte) 0x08, (byte) 0x6c, (byte) 0x19, (byte) 0x0e, (byte) 0x48, (byte) 0xb3, (byte) 0x9d, (byte) 0x66, (byte) 0xeb, (byte) 0x00, (byte) 0x06, (byte) 0xa2,
+            (byte) 0x5a, (byte) 0xee, (byte) 0xa1, (byte) 0x1b, (byte) 0x13, (byte) 0x87, (byte) 0x3c, (byte) 0xd7, (byte) 0x19, (byte) 0xe6, (byte) 0x55, (byte) 0xbd};
+    private final DiffieHellman keys;
+    private final Inner inner;
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(new NameThreadFactory(r -> "session-scheduler-" + r.hashCode()));
+    private final ExecutorService executorService = Executors.newCachedThreadPool(new NameThreadFactory(r -> "handle-packet-" + r.hashCode()));
+    private final AtomicBoolean authLock = new AtomicBoolean(false);
+    private final OkHttpClient client;
+    private final List<CloseListener> closeListeners = Collections.synchronizedList(new ArrayList<>());
+    private final List<ReconnectionListener> reconnectionListeners = Collections.synchronizedList(new ArrayList<>());
     private final Map<String, String> userAttributes = Collections.synchronizedMap(new HashMap<>());
-	private ConnectionHolder conn;
+    private ConnectionHolder conn;
     private volatile CipherPair cipherPair;
-	private Receiver receiver;
-	private Authentication.APWelcome apWelcome = null;
-	private MercuryClient mercuryClient;
-	private Player player;
-	private AudioKeyManager audioKeyManager;
-	private ChannelManager channelManager;
-	private TokenProvider tokenProvider;
-	private CdnManager cdnManager;
-	private CacheManager cacheManager;
-	private DealerClient dealer;
-	private ApiClient api;
-	private SearchManager search;
-	private PlayableContentFeeder contentFeeder;
-	private String countryCode = null;
-	private volatile boolean closed = false;
-	private volatile ScheduledFuture<?> scheduledReconnect = null;
+    private Receiver receiver;
+    private Authentication.APWelcome apWelcome = null;
+    private MercuryClient mercuryClient;
+    private Player player;
+    private AudioKeyManager audioKeyManager;
+    private ChannelManager channelManager;
+    private TokenProvider tokenProvider;
+    private CdnManager cdnManager;
+    private CacheManager cacheManager;
+    private DealerClient dealer;
+    private ApiClient api;
+    private SearchManager search;
+    private PlayableContentFeeder contentFeeder;
+    private String countryCode = null;
+    private volatile boolean closed = false;
+    private volatile ScheduledFuture<?> scheduledReconnect = null;
 
-	private Session(Inner inner, String addr) throws IOException {
-		this.inner = inner;
-		this.keys = new DiffieHellman(inner.random);
-		this.conn = ConnectionHolder.create(addr, inner.configuration);
-		this.client = createClient(inner.configuration);
+    private Session(Inner inner, String addr) throws IOException {
+        this.inner = inner;
+        this.keys = new DiffieHellman(inner.random);
+        this.conn = ConnectionHolder.create(addr, inner.configuration);
+        this.client = createClient(inner.configuration);
 
-		LOGGER.info(String.format("Created new session! {deviceId: %s, ap: %s, proxy: %b} ", inner.deviceId, addr, inner.configuration.proxyEnabled()));
-	}
+        LOGGER.info(String.format("Created new session! {deviceId: %s, ap: %s, proxy: %b} ", inner.deviceId, addr, inner.configuration.proxyEnabled()));
+    }
 
-	@NotNull
-	private static OkHttpClient createClient(@NotNull ProxyConfiguration conf) {
-		OkHttpClient.Builder builder = new OkHttpClient.Builder();
-		builder.retryOnConnectionFailure(true);
+    @NotNull
+    private static OkHttpClient createClient(@NotNull ProxyConfiguration conf) {
+        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        builder.retryOnConnectionFailure(true);
 
-		if (conf.proxyEnabled() && conf.proxyType() != Proxy.Type.DIRECT) {
-			builder.proxy(new Proxy(conf.proxyType(), new InetSocketAddress(conf.proxyAddress(), conf.proxyPort())));
-			if (conf.proxyAuth()) {
-				builder.proxyAuthenticator(new Authenticator() {
-					final String username = conf.proxyUsername();
-					final String password = conf.proxyPassword();
+        if (conf.proxyEnabled() && conf.proxyType() != Proxy.Type.DIRECT) {
+            builder.proxy(new Proxy(conf.proxyType(), new InetSocketAddress(conf.proxyAddress(), conf.proxyPort())));
+            if (conf.proxyAuth()) {
+                builder.proxyAuthenticator(new Authenticator() {
+                    final String username = conf.proxyUsername();
+                    final String password = conf.proxyPassword();
 
-					@Override
-					public Request authenticate(Route route, @NotNull Response response) {
-						String credential = Credentials.basic(username, password);
-						return response.request().newBuilder().header("Proxy-Authorization", credential).build();
-					}
-				});
-			}
-		}
+                    @Override
+                    public Request authenticate(Route route, @NotNull Response response) {
+                        String credential = Credentials.basic(username, password);
+                        return response.request().newBuilder().header("Proxy-Authorization", credential).build();
+                    }
+                });
+            }
+        }
 
-		return builder.build();
-	}
+        return builder.build();
+    }
 
-	private static int readBlobInt(ByteBuffer buffer) {
-		int lo = buffer.get();
-		if ((lo & 0x80) == 0)
-			return lo;
-		int hi = buffer.get();
-		return lo & 0x7f | hi << 7;
-	}
+    private static int readBlobInt(ByteBuffer buffer) {
+        int lo = buffer.get();
+        if ((lo & 0x80) == 0)
+            return lo;
+        int hi = buffer.get();
+        return lo & 0x7f | hi << 7;
+    }
 
-	@NotNull
-	static Session from(@NotNull Inner inner) throws IOException {
-		ApResolver.fillPool();
-		TimeProvider.init(inner.configuration);
-		return new Session(inner, ApResolver.getRandomAccesspoint());
-	}
+    @NotNull
+    static Session from(@NotNull Inner inner) throws IOException {
+        ApResolver.fillPool();
+        TimeProvider.init(inner.configuration);
+        return new Session(inner, ApResolver.getRandomAccesspoint());
+    }
 
-	@NotNull
-	public OkHttpClient client() {
-		return client;
-	}
+    @NotNull
+    public OkHttpClient client() {
+        return client;
+    }
 
-	void connect() throws IOException, GeneralSecurityException, SpotifyAuthenticationException {
-		Accumulator acc = new Accumulator();
+    void connect() throws IOException, GeneralSecurityException, SpotifyAuthenticationException {
+        Accumulator acc = new Accumulator();
 
-		// Send ClientHello
+        // Send ClientHello
 
-		byte[] nonce = new byte[0x10];
-		inner.random.nextBytes(nonce);
+        byte[] nonce = new byte[0x10];
+        inner.random.nextBytes(nonce);
 
-		Keyexchange.ClientHello clientHello = Keyexchange.ClientHello.newBuilder().setBuildInfo(Version.standardBuildInfo())
-				.addCryptosuitesSupported(Keyexchange.Cryptosuite.CRYPTO_SUITE_SHANNON).setLoginCryptoHello(Keyexchange.LoginCryptoHelloUnion.newBuilder()
-						.setDiffieHellman(Keyexchange.LoginCryptoDiffieHellmanHello.newBuilder().setGc(ByteString.copyFrom(keys.publicKeyArray())).setServerKeysKnown(1).build()).build())
-				.setClientNonce(ByteString.copyFrom(nonce)).setPadding(ByteString.copyFrom(new byte[] {0x1e})).build();
+        Keyexchange.ClientHello clientHello = Keyexchange.ClientHello.newBuilder().setBuildInfo(Version.standardBuildInfo())
+                .addCryptosuitesSupported(Keyexchange.Cryptosuite.CRYPTO_SUITE_SHANNON).setLoginCryptoHello(Keyexchange.LoginCryptoHelloUnion.newBuilder()
+                        .setDiffieHellman(Keyexchange.LoginCryptoDiffieHellmanHello.newBuilder().setGc(ByteString.copyFrom(keys.publicKeyArray())).setServerKeysKnown(1).build()).build())
+                .setClientNonce(ByteString.copyFrom(nonce)).setPadding(ByteString.copyFrom(new byte[]{0x1e})).build();
 
-		byte[] clientHelloBytes = clientHello.toByteArray();
-		int length = 2 + 4 + clientHelloBytes.length;
-		conn.out.writeByte(0);
-		conn.out.writeByte(4);
-		conn.out.writeInt(length);
-		conn.out.write(clientHelloBytes);
-		conn.out.flush();
+        byte[] clientHelloBytes = clientHello.toByteArray();
+        int length = 2 + 4 + clientHelloBytes.length;
+        conn.out.writeByte(0);
+        conn.out.writeByte(4);
+        conn.out.writeInt(length);
+        conn.out.write(clientHelloBytes);
+        conn.out.flush();
 
-		acc.writeByte(0);
-		acc.writeByte(4);
-		acc.writeInt(length);
-		acc.write(clientHelloBytes);
+        acc.writeByte(0);
+        acc.writeByte(4);
+        acc.writeInt(length);
+        acc.write(clientHelloBytes);
 
-		// Read APResponseMessage
+        // Read APResponseMessage
 
-		length = conn.in.readInt();
-		acc.writeInt(length);
-		byte[] buffer = new byte[length - 4];
-		conn.in.readFully(buffer);
-		acc.write(buffer);
-		acc.dump();
+        length = conn.in.readInt();
+        acc.writeInt(length);
+        byte[] buffer = new byte[length - 4];
+        conn.in.readFully(buffer);
+        acc.write(buffer);
+        acc.dump();
 
-		Keyexchange.APResponseMessage apResponseMessage = Keyexchange.APResponseMessage.parseFrom(buffer);
-		byte[] sharedKey = Utils.toByteArray(keys.computeSharedKey(apResponseMessage.getChallenge().getLoginCryptoChallenge().getDiffieHellman().getGs().toByteArray()));
+        Keyexchange.APResponseMessage apResponseMessage = Keyexchange.APResponseMessage.parseFrom(buffer);
+        byte[] sharedKey = Utils.toByteArray(keys.computeSharedKey(apResponseMessage.getChallenge().getLoginCryptoChallenge().getDiffieHellman().getGs().toByteArray()));
 
-		// Check gs_signature
+        // Check gs_signature
 
-		KeyFactory factory = KeyFactory.getInstance("RSA");
-		PublicKey publicKey = factory.generatePublic(new RSAPublicKeySpec(new BigInteger(1, serverKey), BigInteger.valueOf(65537)));
+        KeyFactory factory = KeyFactory.getInstance("RSA");
+        PublicKey publicKey = factory.generatePublic(new RSAPublicKeySpec(new BigInteger(1, serverKey), BigInteger.valueOf(65537)));
 
-		Signature sig = Signature.getInstance("SHA1withRSA");
-		sig.initVerify(publicKey);
-		sig.update(apResponseMessage.getChallenge().getLoginCryptoChallenge().getDiffieHellman().getGs().toByteArray());
-		if (!sig.verify(apResponseMessage.getChallenge().getLoginCryptoChallenge().getDiffieHellman().getGsSignature().toByteArray()))
-			throw new GeneralSecurityException("Failed signature check!");
+        Signature sig = Signature.getInstance("SHA1withRSA");
+        sig.initVerify(publicKey);
+        sig.update(apResponseMessage.getChallenge().getLoginCryptoChallenge().getDiffieHellman().getGs().toByteArray());
+        if (!sig.verify(apResponseMessage.getChallenge().getLoginCryptoChallenge().getDiffieHellman().getGsSignature().toByteArray()))
+            throw new GeneralSecurityException("Failed signature check!");
 
-		// Solve challenge
+        // Solve challenge
 
-		ByteArrayOutputStream data = new ByteArrayOutputStream(0x64);
+        ByteArrayOutputStream data = new ByteArrayOutputStream(0x64);
 
-		Mac mac = Mac.getInstance("HmacSHA1");
-		mac.init(new SecretKeySpec(sharedKey, "HmacSHA1"));
-		for (int i = 1; i < 6; i++) {
-			mac.update(acc.array());
-			mac.update(new byte[] {(byte) i});
-			data.write(mac.doFinal());
-			mac.reset();
-		}
+        Mac mac = Mac.getInstance("HmacSHA1");
+        mac.init(new SecretKeySpec(sharedKey, "HmacSHA1"));
+        for (int i = 1; i < 6; i++) {
+            mac.update(acc.array());
+            mac.update(new byte[]{(byte) i});
+            data.write(mac.doFinal());
+            mac.reset();
+        }
 
-		byte[] dataArray = data.toByteArray();
-		mac = Mac.getInstance("HmacSHA1");
-		mac.init(new SecretKeySpec(Arrays.copyOfRange(dataArray, 0, 0x14), "HmacSHA1"));
-		mac.update(acc.array());
+        byte[] dataArray = data.toByteArray();
+        mac = Mac.getInstance("HmacSHA1");
+        mac.init(new SecretKeySpec(Arrays.copyOfRange(dataArray, 0, 0x14), "HmacSHA1"));
+        mac.update(acc.array());
 
-		byte[] challenge = mac.doFinal();
-		Keyexchange.ClientResponsePlaintext clientResponsePlaintext = Keyexchange.ClientResponsePlaintext.newBuilder().setLoginCryptoResponse(
-				Keyexchange.LoginCryptoResponseUnion.newBuilder().setDiffieHellman(Keyexchange.LoginCryptoDiffieHellmanResponse.newBuilder().setHmac(ByteString.copyFrom(challenge)).build())
-						.build()).setPowResponse(Keyexchange.PoWResponseUnion.newBuilder().build()).setCryptoResponse(Keyexchange.CryptoResponseUnion.newBuilder().build()).build();
+        byte[] challenge = mac.doFinal();
+        Keyexchange.ClientResponsePlaintext clientResponsePlaintext = Keyexchange.ClientResponsePlaintext.newBuilder().setLoginCryptoResponse(
+                Keyexchange.LoginCryptoResponseUnion.newBuilder().setDiffieHellman(Keyexchange.LoginCryptoDiffieHellmanResponse.newBuilder().setHmac(ByteString.copyFrom(challenge)).build())
+                        .build()).setPowResponse(Keyexchange.PoWResponseUnion.newBuilder().build()).setCryptoResponse(Keyexchange.CryptoResponseUnion.newBuilder().build()).build();
 
-		byte[] clientResponsePlaintextBytes = clientResponsePlaintext.toByteArray();
-		length = 4 + clientResponsePlaintextBytes.length;
-		conn.out.writeInt(length);
-		conn.out.write(clientResponsePlaintextBytes);
-		conn.out.flush();
+        byte[] clientResponsePlaintextBytes = clientResponsePlaintext.toByteArray();
+        length = 4 + clientResponsePlaintextBytes.length;
+        conn.out.writeInt(length);
+        conn.out.write(clientResponsePlaintextBytes);
+        conn.out.flush();
 
-		try {
-			byte[] scrap = new byte[4];
-			conn.socket.setSoTimeout(300);
-			int read = conn.in.read(scrap);
-			if (read == scrap.length) {
-				length = (scrap[0] << 24) | (scrap[1] << 16) | (scrap[2] << 8) | (scrap[3] & 0xFF);
-				byte[] payload = new byte[length - 4];
-				conn.in.readFully(payload);
-				Keyexchange.APLoginFailed failed = Keyexchange.APResponseMessage.parseFrom(payload).getLoginFailed();
-				throw new SpotifyAuthenticationException(failed);
-			} else if (read > 0) {
-				throw new IllegalStateException("Read unknown data!");
-			}
-		} catch (SocketTimeoutException ignored) {
-		} finally {
-			conn.socket.setSoTimeout(0);
-		}
+        try {
+            byte[] scrap = new byte[4];
+            conn.socket.setSoTimeout(300);
+            int read = conn.in.read(scrap);
+            if (read == scrap.length) {
+                length = (scrap[0] << 24) | (scrap[1] << 16) | (scrap[2] << 8) | (scrap[3] & 0xFF);
+                byte[] payload = new byte[length - 4];
+                conn.in.readFully(payload);
+                Keyexchange.APLoginFailed failed = Keyexchange.APResponseMessage.parseFrom(payload).getLoginFailed();
+                throw new SpotifyAuthenticationException(failed);
+            } else if (read > 0) {
+                throw new IllegalStateException("Read unknown data!");
+            }
+        } catch (SocketTimeoutException ignored) {
+        } finally {
+            conn.socket.setSoTimeout(0);
+        }
 
 
-		synchronized (authLock) {
-			// Init Shannon cipher
-			cipherPair = new CipherPair(Arrays.copyOfRange(data.toByteArray(), 0x14, 0x34),
-					Arrays.copyOfRange(data.toByteArray(), 0x34, 0x54));
+        synchronized (authLock) {
+            // Init Shannon cipher
+            cipherPair = new CipherPair(Arrays.copyOfRange(data.toByteArray(), 0x14, 0x34),
+                    Arrays.copyOfRange(data.toByteArray(), 0x34, 0x54));
 
-			authLock.set(true);
-		}
+            authLock.set(true);
+        }
 
-		LOGGER.info("Connected successfully!");
-	}
+        LOGGER.info("Connected successfully!");
+    }
 
-	/**
-	 * Authenticates with the server and creates all the necessary components.
-	 * All of them should be initialized inside the synchronized block and MUST NOT call any method on this {@link Session} object.
-	 */
-	void authenticate(@NotNull Authentication.LoginCredentials credentials) throws IOException, GeneralSecurityException, SpotifyAuthenticationException, MercuryClient.MercuryException {
-		authenticatePartial(credentials, false);
+    /**
+     * Authenticates with the server and creates all the necessary components.
+     * All of them should be initialized inside the synchronized block and MUST NOT call any method on this {@link Session} object.
+     */
+    void authenticate(@NotNull Authentication.LoginCredentials credentials) throws IOException, GeneralSecurityException, SpotifyAuthenticationException, MercuryClient.MercuryException {
+        authenticatePartial(credentials, false);
 
-		synchronized (authLock) {
-			mercuryClient = new MercuryClient(this);
-			tokenProvider = new TokenProvider(this);
-			audioKeyManager = new AudioKeyManager(this);
-			channelManager = new ChannelManager(this);
-			api = new ApiClient(this);
-			cdnManager = new CdnManager(this);
-			contentFeeder = new PlayableContentFeeder(this);
-			cacheManager = new CacheManager(inner.configuration);
-			dealer = new DealerClient(this);
-			player = new Player(inner.configuration, this);
-			search = new SearchManager(this);
+        synchronized (authLock) {
+            mercuryClient = new MercuryClient(this);
+            tokenProvider = new TokenProvider(this);
+            audioKeyManager = new AudioKeyManager(this);
+            channelManager = new ChannelManager(this);
+            api = new ApiClient(this);
+            cdnManager = new CdnManager(this);
+            contentFeeder = new PlayableContentFeeder(this);
+            cacheManager = new CacheManager(inner.configuration);
+            dealer = new DealerClient(this);
+            player = new Player(inner.configuration, this);
+            search = new SearchManager(this);
 
-			authLock.set(false);
-			authLock.notifyAll();
-		}
+            authLock.set(false);
+            authLock.notifyAll();
+        }
 
-		dealer.connect();
-		player.initState();
+        dealer.connect();
+        player.initState();
 
-		TimeProvider.init(this);
+        TimeProvider.init(this);
 
-		LOGGER.info(String.format("Authenticated as %s!", apWelcome.getCanonicalUsername()));
+        LOGGER.info(String.format("Authenticated as %s!", apWelcome.getCanonicalUsername()));
 
 
         mercuryClient.interestedIn("spotify:user:attributes:update", this);
-	}
+    }
 
-	/**
-	 * Authenticates with the server. Does not create all the components unlike {@link Session#authenticate(Authentication.LoginCredentials)}.
-	 *
-	 * @param removeLock Whether {@link Session#authLock} should be released or not.
-	 *                   {@code false} for {@link Session#authenticate(Authentication.LoginCredentials)},
-	 *                   {@code true} for {@link Session#reconnect()}.
-	 */
-	private void authenticatePartial(@NotNull Authentication.LoginCredentials credentials, boolean removeLock) throws IOException, GeneralSecurityException, SpotifyAuthenticationException {
-		if (cipherPair == null)
-			throw new IllegalStateException("Connection not established!");
+    /**
+     * Authenticates with the server. Does not create all the components unlike {@link Session#authenticate(Authentication.LoginCredentials)}.
+     *
+     * @param removeLock Whether {@link Session#authLock} should be released or not.
+     *                   {@code false} for {@link Session#authenticate(Authentication.LoginCredentials)},
+     *                   {@code true} for {@link Session#reconnect()}.
+     */
+    private void authenticatePartial(@NotNull Authentication.LoginCredentials credentials, boolean removeLock) throws IOException, GeneralSecurityException, SpotifyAuthenticationException {
+        if (cipherPair == null)
+            throw new IllegalStateException("Connection not established!");
 
         Authentication.ClientResponseEncrypted clientResponseEncrypted = Authentication.ClientResponseEncrypted.newBuilder()
                 .setLoginCredentials(credentials)
                 .setSystemInfo(Authentication.SystemInfo.newBuilder()
                         .setOs(Authentication.Os.OS_UNKNOWN)
                         .setCpuFamily(Authentication.CpuFamily.CPU_UNKNOWN)
-						.setSystemInformationString(Version.systemInfoString()).setDeviceId(inner.deviceId).build()).setVersionString(Version.versionString()).build();
+                        .setSystemInformationString(Version.systemInfoString()).setDeviceId(inner.deviceId).build()).setVersionString(Version.versionString()).build();
 
-		sendUnchecked(Packet.Type.Login, clientResponseEncrypted.toByteArray());
+        sendUnchecked(Packet.Type.Login, clientResponseEncrypted.toByteArray());
 
-		Packet packet = cipherPair.receiveEncoded(conn.in);
-		if (packet.is(Packet.Type.APWelcome)) {
-			apWelcome = Authentication.APWelcome.parseFrom(packet.payload);
+        Packet packet = cipherPair.receiveEncoded(conn.in);
+        if (packet.is(Packet.Type.APWelcome)) {
+            apWelcome = Authentication.APWelcome.parseFrom(packet.payload);
 
-			receiver = new Receiver();
-			new Thread(receiver, "session-packet-receiver").start();
+            receiver = new Receiver();
+            new Thread(receiver, "session-packet-receiver").start();
 
-			byte[] bytes0x0f = new byte[20];
-			random().nextBytes(bytes0x0f);
-			sendUnchecked(Packet.Type.Unknown_0x0f, bytes0x0f);
+            byte[] bytes0x0f = new byte[20];
+            random().nextBytes(bytes0x0f);
+            sendUnchecked(Packet.Type.Unknown_0x0f, bytes0x0f);
 
-			ByteBuffer preferredLocale = ByteBuffer.allocate(18 + 5);
-			preferredLocale.put((byte) 0x0).put((byte) 0x0).put((byte) 0x10).put((byte) 0x0).put((byte) 0x02);
-			preferredLocale.put("preferred-locale".getBytes());
-			preferredLocale.put(inner.configuration.preferredLocale().getBytes());
-			sendUnchecked(Packet.Type.PreferredLocale, preferredLocale.array());
+            ByteBuffer preferredLocale = ByteBuffer.allocate(18 + 5);
+            preferredLocale.put((byte) 0x0).put((byte) 0x0).put((byte) 0x10).put((byte) 0x0).put((byte) 0x02);
+            preferredLocale.put("preferred-locale".getBytes());
+            preferredLocale.put(inner.configuration.preferredLocale().getBytes());
+            sendUnchecked(Packet.Type.PreferredLocale, preferredLocale.array());
 
-			if (removeLock) {
-				synchronized (authLock) {
-					authLock.set(false);
-					authLock.notifyAll();
-				}
-			}
+            if (removeLock) {
+                synchronized (authLock) {
+                    authLock.set(false);
+                    authLock.notifyAll();
+                }
+            }
 
-			if (conf().storeCredentials()) {
-				ByteString reusable = apWelcome.getReusableAuthCredentials();
-				Authentication.AuthenticationType reusableType = apWelcome.getReusableAuthCredentialsType();
+            if (conf().storeCredentials()) {
+                ByteString reusable = apWelcome.getReusableAuthCredentials();
+                Authentication.AuthenticationType reusableType = apWelcome.getReusableAuthCredentialsType();
 
-				JsonObject obj = new JsonObject();
-				obj.addProperty("username", apWelcome.getCanonicalUsername());
-				obj.addProperty("credentials", Utils.toBase64(reusable));
-				obj.addProperty("type", reusableType.name());
+                JsonObject obj = new JsonObject();
+                obj.addProperty("username", apWelcome.getCanonicalUsername());
+                obj.addProperty("credentials", Utils.toBase64(reusable));
+                obj.addProperty("type", reusableType.name());
 
-				File storeFile = conf().credentialsFile();
-				if (storeFile == null)
-					throw new IllegalArgumentException();
-				try (FileOutputStream out = new FileOutputStream(storeFile)) {
-					out.write(obj.toString().getBytes());
-				}
-			}
-		} else if (packet.is(Packet.Type.AuthFailure)) {
-			throw new SpotifyAuthenticationException(Keyexchange.APLoginFailed.parseFrom(packet.payload));
-		} else {
-			throw new IllegalStateException("Unknown CMD 0x" + Integer.toHexString(packet.cmd));
-		}
-	}
+                File storeFile = conf().credentialsFile();
+                if (storeFile == null)
+                    throw new IllegalArgumentException();
+                try (FileOutputStream out = new FileOutputStream(storeFile)) {
+                    out.write(obj.toString().getBytes());
+                }
+            }
+        } else if (packet.is(Packet.Type.AuthFailure)) {
+            throw new SpotifyAuthenticationException(Keyexchange.APLoginFailed.parseFrom(packet.payload));
+        } else {
+            throw new IllegalStateException("Unknown CMD 0x" + Integer.toHexString(packet.cmd));
+        }
+    }
 
-	@Override
-	public void close() throws IOException {
-		LOGGER.info(String.format("Closing session. {deviceId: %s} ", inner.deviceId));
+    @Override
+    public void close() throws IOException {
+        LOGGER.info(String.format("Closing session. {deviceId: %s} ", inner.deviceId));
 
-		scheduler.shutdownNow();
+        scheduler.shutdownNow();
 
-		if (receiver != null) {
-			receiver.stop();
-			receiver = null;
-		}
-
-		if (player != null) {
-			player.close();
-			player = null;
-		}
-
-		if (dealer != null) {
-			dealer.close();
-			dealer = null;
-		}
-
-		if (audioKeyManager != null) {
-			audioKeyManager.close();
-			audioKeyManager = null;
-		}
-
-		if (channelManager != null) {
-			channelManager.close();
-			channelManager = null;
-		}
-
-		if (mercuryClient != null) {
-			mercuryClient.close();
-			mercuryClient = null;
-		}
-
-		executorService.shutdown();
-
-		if (conn != null) {
-			conn.socket.close();
-			conn = null;
-		}
-
-        synchronized (authLock) {
-		apWelcome = null;
-		cipherPair = null;
-		closed = true;
+        if (receiver != null) {
+            receiver.stop();
+            receiver = null;
         }
 
-		synchronized (closeListeners) {
-			Iterator<CloseListener> i = closeListeners.iterator();
-			while (i.hasNext()) {
-				i.next().onClosed();
-				i.remove();
-			}
-		}
+        if (player != null) {
+            player.close();
+            player = null;
+        }
 
-		LOGGER.info(String.format("Closed session. {deviceId: %s} ", inner.deviceId));
-	}
+        if (dealer != null) {
+            dealer.close();
+            dealer = null;
+        }
 
-	private void sendUnchecked(Packet.Type cmd, byte[] payload) throws IOException {
-		cipherPair.sendEncoded(conn.out, cmd.val, payload);
-	}
+        if (audioKeyManager != null) {
+            audioKeyManager.close();
+            audioKeyManager = null;
+        }
 
-	private void waitAuthLock() {
+        if (channelManager != null) {
+            channelManager.close();
+            channelManager = null;
+        }
+
+        if (mercuryClient != null) {
+            mercuryClient.close();
+            mercuryClient = null;
+        }
+
+        executorService.shutdown();
+
+        if (conn != null) {
+            conn.socket.close();
+            conn = null;
+        }
+
+        synchronized (authLock) {
+            apWelcome = null;
+            cipherPair = null;
+            closed = true;
+        }
+
+        synchronized (closeListeners) {
+            Iterator<CloseListener> i = closeListeners.iterator();
+            while (i.hasNext()) {
+                i.next().onClosed();
+                i.remove();
+            }
+        }
+
+        LOGGER.info(String.format("Closed session. {deviceId: %s} ", inner.deviceId));
+    }
+
+    private void sendUnchecked(Packet.Type cmd, byte[] payload) throws IOException {
+        cipherPair.sendEncoded(conn.out, cmd.val, payload);
+    }
+
+    private void waitAuthLock() {
         if (closed) throw new IllegalStateException("Session is closed!");
 
         synchronized (authLock) {
@@ -459,626 +459,626 @@ public final class Session implements Closeable, SubListener {
                 }
             }
 
-		sendUnchecked(cmd, payload);
-	}
+            sendUnchecked(cmd, payload);
+        }
     }
 
-	@NotNull
-	public MercuryClient mercury() {
-		waitAuthLock();
-		if (mercuryClient == null)
-			throw new IllegalStateException("Session isn't authenticated!");
-		return mercuryClient;
-	}
-
-	@NotNull
-	public AudioKeyManager audioKey() {
-		waitAuthLock();
-		if (audioKeyManager == null)
-			throw new IllegalStateException("Session isn't authenticated!");
-		return audioKeyManager;
-	}
-
-	@NotNull
-	public CacheManager cache() {
-		waitAuthLock();
-		if (cacheManager == null)
-			throw new IllegalStateException("Session isn't authenticated!");
-		return cacheManager;
-	}
-
-	@NotNull
-	public CdnManager cdn() {
-		waitAuthLock();
-		if (cdnManager == null)
-			throw new IllegalStateException("Session isn't authenticated!");
-		return cdnManager;
-	}
-
-	@NotNull
-	public ChannelManager channel() {
-		waitAuthLock();
-		if (channelManager == null)
-			throw new IllegalStateException("Session isn't authenticated!");
-		return channelManager;
-	}
-
-	@NotNull
-	public TokenProvider tokens() {
-		waitAuthLock();
-		if (tokenProvider == null)
-			throw new IllegalStateException("Session isn't authenticated!");
-		return tokenProvider;
-	}
-
-	@NotNull
-	public DealerClient dealer() {
-		waitAuthLock();
-		if (dealer == null)
-			throw new IllegalStateException("Session isn't authenticated!");
-		return dealer;
-	}
-
-	@NotNull
-	public ApiClient api() {
-		waitAuthLock();
-		if (api == null)
-			throw new IllegalStateException("Session isn't authenticated!");
-		return api;
-	}
-
-	@NotNull
-	public PlayableContentFeeder contentFeeder() {
-		waitAuthLock();
-		if (contentFeeder == null)
-			throw new IllegalStateException("Session isn't authenticated!");
-		return contentFeeder;
-	}
-
-	@NotNull
-	public Player player() {
-		waitAuthLock();
-		if (player == null)
-			throw new IllegalStateException("Session isn't authenticated!");
-		return player;
-	}
-
-	@NotNull
-	public SearchManager search() {
-		waitAuthLock();
-		if (search == null)
-			throw new IllegalStateException("Session isn't authenticated!");
-		return search;
-	}
-
-	@NotNull
-	public String username() {
-		return apWelcome().getCanonicalUsername();
-	}
-
-	@NotNull
-	public Authentication.APWelcome apWelcome() {
-		waitAuthLock();
-		if (apWelcome == null)
-			throw new IllegalStateException("Session isn't authenticated!");
-		return apWelcome;
-	}
-
-	public boolean valid() {
-		if (closed)
-			return false;
-
-		waitAuthLock();
-		return apWelcome != null && conn != null && !conn.socket.isClosed();
-	}
-
-	public boolean reconnecting() {
-		return !closed && conn == null;
-	}
-
-	@NotNull
-	public String deviceId() {
-		return inner.deviceId;
-	}
-
-	@NotNull
-	public Connect.DeviceType deviceType() {
-		return inner.deviceType;
-	}
-
-	@NotNull ExecutorService executor() {
-		return executorService;
-	}
-
-	@NotNull
-	public String deviceName() {
-		return inner.deviceName;
-	}
-
-	@NotNull
-	public Random random() {
-		return inner.random;
-	}
-
-	private void reconnect() {
-		synchronized (reconnectionListeners) {
-			reconnectionListeners.forEach(ReconnectionListener::onConnectionDropped);
-		}
-
-		try {
-			if (conn != null) {
-				conn.socket.close();
-				receiver.stop();
-			}
-
-			conn = ConnectionHolder.create(ApResolver.getRandomAccesspoint(), conf());
-			connect();
-			authenticatePartial(Authentication.LoginCredentials.newBuilder().setUsername(apWelcome.getCanonicalUsername()).setTyp(apWelcome.getReusableAuthCredentialsType())
-					.setAuthData(apWelcome.getReusableAuthCredentials()).build(), true);
-
-			LOGGER.info(String.format("Re-authenticated as %s!", apWelcome.getCanonicalUsername()));
-
-			synchronized (reconnectionListeners) {
-				reconnectionListeners.forEach(ReconnectionListener::onConnectionEstablished);
-			}
-		} catch (IOException | GeneralSecurityException | SpotifyAuthenticationException ex) {
-			conn = null;
-			LOGGER.error("Failed reconnecting, retrying in 10 seconds...", ex);
-			scheduler.schedule(this::reconnect, 10, TimeUnit.SECONDS);
-		}
-	}
-
-	@NotNull
-	public AbsConfiguration conf() {
-		return inner.configuration;
-	}
-
-	@Nullable
-	public String countryCode() {
-		return countryCode;
-	}
-
-	public void addCloseListener(@NotNull CloseListener listener) {
-		if (!closeListeners.contains(listener))
-			closeListeners.add(listener);
-	}
-
-	public void addReconnectionListener(@NotNull ReconnectionListener listener) {
-		if (!reconnectionListeners.contains(listener))
-			reconnectionListeners.add(listener);
-	}
-
-	private void parseProductInfo(@NotNull InputStream in) throws IOException, SAXException, ParserConfigurationException {
-		DocumentBuilder dBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-		Document doc = dBuilder.parse(in);
-
-		Node products = doc.getElementsByTagName("products").item(0);
-		if (products == null) return;
-
-		Node product = products.getChildNodes().item(0);
-		if (product == null) return;
-
-		NodeList properties = product.getChildNodes();
-		for (int i = 0; i < properties.getLength(); i++) {
-			Node node = properties.item(i);
-			userAttributes.put(node.getNodeName(), node.getTextContent());
-		}
-
-		LOGGER.trace("Parsed product info: " + userAttributes);
-	}
-
-	@Nullable
-	public String getUserAttribute(@NotNull String key) {
-		return userAttributes.get(key);
-	}
-
-	@Contract("_, !null -> !null")
-	public String getUserAttribute(@NotNull String key, @NotNull String fallback) {
-		return userAttributes.getOrDefault(key, fallback);
-	}
-
-	@Override
-	public void event(@NotNull MercuryClient.Response resp) {
-		if (resp.uri.equals("spotify:user:attributes:update")) {
-			UserAttributesUpdate attributesUpdate;
-			try {
-				attributesUpdate = UserAttributesUpdate.parseFrom(resp.payload.stream());
-			} catch (IOException ex) {
-				LOGGER.warn("Failed parsing user attributes update.", ex);
-				return;
-			}
-
-			for (ExplicitContentPubsub.KeyValuePair pair : attributesUpdate.getPairsList()) {
-				userAttributes.put(pair.getKey(), pair.getValue());
-				LOGGER.trace(String.format("Updated user attribute: %s -> %s", pair.getKey(), pair.getValue()));
-			}
-		}
-	}
-
-	public interface ReconnectionListener {
-		void onConnectionDropped();
-
-		void onConnectionEstablished();
-	}
-
-	public interface ProxyConfiguration {
-		boolean proxyEnabled();
-
-		@NotNull Proxy.Type proxyType();
-
-		@NotNull String proxyAddress();
-
-		int proxyPort();
-
-		boolean proxyAuth();
-
-		@NotNull String proxyUsername();
-
-		@NotNull String proxyPassword();
-	}
-
-	public interface CloseListener {
-		void onClosed();
-	}
-
-	static class Inner {
-		final Connect.DeviceType deviceType;
-		final String deviceName;
-		final SecureRandom random;
-		final String deviceId;
-		final AbsConfiguration configuration;
-
-		private Inner(Connect.DeviceType deviceType, String deviceName, AbsConfiguration configuration) {
-			this.deviceType = deviceType;
-			this.deviceName = deviceName;
-			this.configuration = configuration;
-			this.random = new SecureRandom();
-
-			String configuredDeviceId = configuration.deviceId();
-			this.deviceId = (configuredDeviceId == null || configuredDeviceId.isEmpty()) ? Utils.randomHexString(random, 40).toLowerCase() : configuredDeviceId;
-		}
-
-		@NotNull
-		static Inner from(@NotNull AbsConfiguration configuration) {
-			String deviceName = configuration.deviceName();
-			if (deviceName == null || deviceName.isEmpty())
-				throw new IllegalArgumentException("Device name required: " + deviceName);
-
-			Connect.DeviceType deviceType = configuration.deviceType();
-			if (deviceType == null)
-				throw new IllegalArgumentException("Device type required!");
-
-			return new Inner(deviceType, deviceName, configuration);
-		}
-
-		@NotNull Authentication.LoginCredentials decryptBlob(String username, byte[] encryptedBlob) throws GeneralSecurityException, IOException {
-			encryptedBlob = Base64.getDecoder().decode(encryptedBlob);
-
-			byte[] secret = MessageDigest.getInstance("SHA-1").digest(deviceId.getBytes());
-			byte[] baseKey = PBKDF2.HmacSHA1(secret, username.getBytes(), 0x100, 20);
-
-			byte[] key = ByteBuffer.allocate(24).put(MessageDigest.getInstance("SHA-1").digest(baseKey)).putInt(20).array();
-
-			Cipher aes = Cipher.getInstance("AES/ECB/NoPadding");
-			aes.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"));
-			byte[] decryptedBlob = aes.doFinal(encryptedBlob);
-
-			int l = decryptedBlob.length;
-			for (int i = 0; i < l - 0x10; i++)
-				decryptedBlob[l - i - 1] ^= decryptedBlob[l - i - 0x11];
-
-			ByteBuffer blob = ByteBuffer.wrap(decryptedBlob);
-			blob.get();
-			int len = readBlobInt(blob);
-			blob.get(new byte[len]);
-			blob.get();
-
-			int typeInt = readBlobInt(blob);
-			Authentication.AuthenticationType type = Authentication.AuthenticationType.forNumber(typeInt);
-			if (type == null)
-				throw new IOException(new IllegalArgumentException("Unknown AuthenticationType: " + typeInt));
-
-			blob.get();
-
-			len = readBlobInt(blob);
-			byte[] authData = new byte[len];
-			blob.get(authData);
-
-			return Authentication.LoginCredentials.newBuilder().setUsername(username).setTyp(type).setAuthData(ByteString.copyFrom(authData)).build();
-		}
-	}
-
-	/**
-	 * Builder for setting up a {@link Session} object.
-	 */
-	public static class Builder {
-		private final Inner inner;
-		private final AuthConfiguration authConf;
-		private Authentication.LoginCredentials loginCredentials = null;
-
-		public Builder(@NotNull Connect.DeviceType deviceType, @NotNull String deviceName, @NotNull AbsConfiguration configuration) {
-			this.inner = new Inner(deviceType, deviceName, configuration);
-			this.authConf = configuration;
-		}
-
-		public Builder(@NotNull AbsConfiguration configuration) {
-			this.inner = Inner.from(configuration);
-			this.authConf = configuration;
-		}
-
-		/**
-		 * Authenticate with your Facebook account, will prompt to open a link in the browser.
-		 */
-		@NotNull
-		public Builder facebook() throws IOException {
-			try (FacebookAuthenticator authenticator = new FacebookAuthenticator()) {
-				loginCredentials = authenticator.lockUntilCredentials();
-				return this;
-			} catch (InterruptedException ex) {
-				throw new IOException(ex);
-			}
-		}
-
-		/**
-		 * Authenticate with a saved credentials blob.
-		 *
-		 * @param username Your Spotify username
-		 * @param blob     The Base64-decoded blob
-		 */
-		@NotNull
-		public Builder blob(String username, byte[] blob) throws GeneralSecurityException, IOException {
-			loginCredentials = inner.decryptBlob(username, blob);
-			return this;
-		}
-
-		/**
-		 * Authenticate with username and password. The credentials won't be saved.
-		 *
-		 * @param username Your Spotify username
-		 * @param password Your Spotify password
-		 */
-		@NotNull
-		public Builder userPass(@NotNull String username, @NotNull String password) {
-			loginCredentials = Authentication.LoginCredentials.newBuilder().setUsername(username).setTyp(Authentication.AuthenticationType.AUTHENTICATION_USER_PASS)
-					.setAuthData(ByteString.copyFromUtf8(password)).build();
-			return this;
-		}
-
-		/**
-		 * Creates a connected and fully authenticated {@link Session} object.
-		 */
-		@NotNull
-		public Session create() throws IOException, GeneralSecurityException, SpotifyAuthenticationException, MercuryClient.MercuryException {
-			if (authConf.storeCredentials()) {
-				File storeFile = authConf.credentialsFile();
-				if (storeFile != null && storeFile.exists()) {
-					JsonObject obj = JsonParser.parseReader(new FileReader(storeFile)).getAsJsonObject();
-					loginCredentials = Authentication.LoginCredentials.newBuilder().setTyp(Authentication.AuthenticationType.valueOf(obj.get("type").getAsString()))
-							.setUsername(obj.get("username").getAsString()).setAuthData(Utils.fromBase64(obj.get("credentials").getAsString())).build();
-				}
-			}
-
-			if (loginCredentials == null) {
-				String blob = authConf.authBlob();
-				String username = authConf.authUsername();
-				String password = authConf.authPassword();
-
-				switch (authConf.authStrategy()) {
-					case FACEBOOK:
-						facebook();
-						break;
-					case BLOB:
-						if (username == null)
-							throw new IllegalArgumentException("Missing authUsername!");
-						if (blob == null)
-							throw new IllegalArgumentException("Missing authBlob!");
-						blob(username, Base64.getDecoder().decode(blob));
-						break;
-					case USER_PASS:
-						if (username == null)
-							throw new IllegalArgumentException("Missing authUsername!");
-						if (password == null)
-							throw new IllegalArgumentException("Missing authPassword!");
-						userPass(username, password);
-						break;
-					case ZEROCONF:
-						throw new IllegalStateException("Cannot handle ZEROCONF! Use ZeroconfServer.");
-					default:
-						throw new IllegalStateException("Unknown auth authStrategy: " + authConf.authStrategy());
-				}
-			}
-
-			Session session = Session.from(inner);
-			session.connect();
-			session.authenticate(loginCredentials);
-			return session;
-		}
-	}
-
-	public static class SpotifyAuthenticationException extends Exception {
-		private SpotifyAuthenticationException(Keyexchange.APLoginFailed loginFailed) {
-			super(loginFailed.getErrorCode().name());
-		}
-	}
-
-	private static class Accumulator extends DataOutputStream {
-		private byte[] bytes;
-
-		Accumulator() {
-			super(new ByteArrayOutputStream());
-		}
-
-		void dump() throws IOException {
-			bytes = ((ByteArrayOutputStream) this.out).toByteArray();
-			this.close();
-		}
-
-		@NotNull byte[] array() {
-			return bytes;
-		}
-	}
-
-	private static class ConnectionHolder {
-		final Socket socket;
-		final DataInputStream in;
-		final DataOutputStream out;
-
-		private ConnectionHolder(@NotNull Socket socket) throws IOException {
-			this.socket = socket;
-			this.in = new DataInputStream(socket.getInputStream());
-			this.out = new DataOutputStream(socket.getOutputStream());
-		}
-
-		@NotNull
-		static ConnectionHolder create(@NotNull String addr, @NotNull ProxyConfiguration conf) throws IOException {
-			int colon = addr.indexOf(':');
-			String apAddr = addr.substring(0, colon);
-			int apPort = Integer.parseInt(addr.substring(colon + 1));
-			if (!conf.proxyEnabled() || conf.proxyType() == Proxy.Type.DIRECT)
-				return new ConnectionHolder(new Socket(apAddr, apPort));
-
-			switch (conf.proxyType()) {
-				case HTTP:
-					Socket sock = new Socket(conf.proxyAddress(), conf.proxyPort());
-					OutputStream out = sock.getOutputStream();
-					DataInputStream in = new DataInputStream(sock.getInputStream());
-
-					out.write(String.format("CONNECT %s:%d HTTP/1.0\n", apAddr, apPort).getBytes());
-					if (conf.proxyAuth()) {
-						out.write("Proxy-Authorization: Basic ".getBytes());
-						out.write(Base64.getEncoder().encodeToString(String.format("%s:%s\n", conf.proxyUsername(), conf.proxyPassword()).getBytes()).getBytes());
-					}
-
-					out.write('\n');
-					out.flush();
-
-					String sl = Utils.readLine(in);
-					if (!sl.contains("200"))
-						throw new IOException("Failed connecting: " + sl);
-
-					//noinspection StatementWithEmptyBody
-					while (!Utils.readLine(in).isEmpty()) {
-						// Read all headers
-					}
-
-					LOGGER.info("Successfully connected to the HTTP proxy.");
-					return new ConnectionHolder(sock);
-				case SOCKS:
-					if (conf.proxyAuth()) {
-						java.net.Authenticator.setDefault(new java.net.Authenticator() {
-							final String username = conf.proxyUsername();
-							final String password = conf.proxyPassword();
-
-							@Override
-							protected PasswordAuthentication getPasswordAuthentication() {
-								if (Objects.equals(getRequestingProtocol(), "SOCKS5") && Objects.equals(getRequestingPrompt(), "SOCKS authentication"))
-									return new PasswordAuthentication(username, password.toCharArray());
-
-								return super.getPasswordAuthentication();
-							}
-						});
-					}
-
-					Proxy proxy = new Proxy(conf.proxyType(), new InetSocketAddress(conf.proxyAddress(), conf.proxyPort()));
-					Socket proxySocket = new Socket(proxy);
-					proxySocket.connect(new InetSocketAddress(apAddr, apPort));
-					LOGGER.info("Successfully connected to the SOCKS proxy.");
-					return new ConnectionHolder(proxySocket);
-				case DIRECT:
-				default:
-					throw new UnsupportedOperationException();
-			}
-		}
-	}
-
-	private class Receiver implements Runnable {
-		private volatile boolean shouldStop = false;
-		private Thread thread;
-
-		private Receiver() {
-		}
-
-		void stop() {
-			shouldStop = true;
-			thread.interrupt();
-		}
-
-		@Override
-		public void run() {
-			LOGGER.trace("Session.Receiver started");
-			this.thread = Thread.currentThread();
-			while (!shouldStop) {
-				Packet packet;
-				Packet.Type cmd;
-				try {
-					packet = cipherPair.receiveEncoded(conn.in);
-					cmd = Packet.Type.parse(packet.cmd);
-					if (cmd == null) {
-						LOGGER.info(String.format("Skipping unknown command {cmd: 0x%s, payload: %s}", Integer.toHexString(packet.cmd), Utils.bytesToHex(packet.payload)));
-						continue;
-					}
-				} catch (IOException | GeneralSecurityException ex) {
-					if (!shouldStop) {
-						LOGGER.fatal("Failed reading packet!", ex);
-						reconnect();
-					}
-
-					break;
-				}
-
-				if (shouldStop) break;
-
-				switch (cmd) {
-					case Ping:
-						if (scheduledReconnect != null)
-							scheduledReconnect.cancel(true);
-						scheduledReconnect = scheduler.schedule(() -> {
-							LOGGER.warn("Socket timed out. Reconnecting...");
-							reconnect();
-						}, 2 * 60 + 5, TimeUnit.SECONDS);
-
-						TimeProvider.updateWithPing(packet.payload);
-
-						try {
-							send(Packet.Type.Pong, packet.payload);
-						} catch (IOException ex) {
-							LOGGER.fatal("Failed sending Pong!", ex);
-						}
-						break;
-					case PongAck:
-						// Silent
-						break;
-					case CountryCode:
-						countryCode = new String(packet.payload);
-						LOGGER.info("Received CountryCode: " + countryCode);
-						break;
-					case LicenseVersion:
-						ByteBuffer licenseVersion = ByteBuffer.wrap(packet.payload);
-						short id = licenseVersion.getShort();
-						if (id != 0) {
-							byte[] buffer = new byte[licenseVersion.get()];
-							licenseVersion.get(buffer);
-							LOGGER.info(String.format("Received LicenseVersion: %d, %s", id, new String(buffer)));
-						} else {
-							LOGGER.info(String.format("Received LicenseVersion: %d", id));
-						}
-						break;
-					case Unknown_0x10:
-						LOGGER.debug("Received 0x10: " + Utils.bytesToHex(packet.payload));
-						break;
-					case MercurySub:
-					case MercuryUnsub:
-					case MercuryEvent:
-					case MercuryReq:
-						mercury().dispatch(packet);
-						break;
-					case AesKey:
-					case AesKeyError:
-						audioKey().dispatch(packet);
-						break;
-					case ChannelError:
-					case StreamChunkRes:
-						channel().dispatch(packet);
+    @NotNull
+    public MercuryClient mercury() {
+        waitAuthLock();
+        if (mercuryClient == null)
+            throw new IllegalStateException("Session isn't authenticated!");
+        return mercuryClient;
+    }
+
+    @NotNull
+    public AudioKeyManager audioKey() {
+        waitAuthLock();
+        if (audioKeyManager == null)
+            throw new IllegalStateException("Session isn't authenticated!");
+        return audioKeyManager;
+    }
+
+    @NotNull
+    public CacheManager cache() {
+        waitAuthLock();
+        if (cacheManager == null)
+            throw new IllegalStateException("Session isn't authenticated!");
+        return cacheManager;
+    }
+
+    @NotNull
+    public CdnManager cdn() {
+        waitAuthLock();
+        if (cdnManager == null)
+            throw new IllegalStateException("Session isn't authenticated!");
+        return cdnManager;
+    }
+
+    @NotNull
+    public ChannelManager channel() {
+        waitAuthLock();
+        if (channelManager == null)
+            throw new IllegalStateException("Session isn't authenticated!");
+        return channelManager;
+    }
+
+    @NotNull
+    public TokenProvider tokens() {
+        waitAuthLock();
+        if (tokenProvider == null)
+            throw new IllegalStateException("Session isn't authenticated!");
+        return tokenProvider;
+    }
+
+    @NotNull
+    public DealerClient dealer() {
+        waitAuthLock();
+        if (dealer == null)
+            throw new IllegalStateException("Session isn't authenticated!");
+        return dealer;
+    }
+
+    @NotNull
+    public ApiClient api() {
+        waitAuthLock();
+        if (api == null)
+            throw new IllegalStateException("Session isn't authenticated!");
+        return api;
+    }
+
+    @NotNull
+    public PlayableContentFeeder contentFeeder() {
+        waitAuthLock();
+        if (contentFeeder == null)
+            throw new IllegalStateException("Session isn't authenticated!");
+        return contentFeeder;
+    }
+
+    @NotNull
+    public Player player() {
+        waitAuthLock();
+        if (player == null)
+            throw new IllegalStateException("Session isn't authenticated!");
+        return player;
+    }
+
+    @NotNull
+    public SearchManager search() {
+        waitAuthLock();
+        if (search == null)
+            throw new IllegalStateException("Session isn't authenticated!");
+        return search;
+    }
+
+    @NotNull
+    public String username() {
+        return apWelcome().getCanonicalUsername();
+    }
+
+    @NotNull
+    public Authentication.APWelcome apWelcome() {
+        waitAuthLock();
+        if (apWelcome == null)
+            throw new IllegalStateException("Session isn't authenticated!");
+        return apWelcome;
+    }
+
+    public boolean valid() {
+        if (closed)
+            return false;
+
+        waitAuthLock();
+        return apWelcome != null && conn != null && !conn.socket.isClosed();
+    }
+
+    public boolean reconnecting() {
+        return !closed && conn == null;
+    }
+
+    @NotNull
+    public String deviceId() {
+        return inner.deviceId;
+    }
+
+    @NotNull
+    public Connect.DeviceType deviceType() {
+        return inner.deviceType;
+    }
+
+    @NotNull ExecutorService executor() {
+        return executorService;
+    }
+
+    @NotNull
+    public String deviceName() {
+        return inner.deviceName;
+    }
+
+    @NotNull
+    public Random random() {
+        return inner.random;
+    }
+
+    private void reconnect() {
+        synchronized (reconnectionListeners) {
+            reconnectionListeners.forEach(ReconnectionListener::onConnectionDropped);
+        }
+
+        try {
+            if (conn != null) {
+                conn.socket.close();
+                receiver.stop();
+            }
+
+            conn = ConnectionHolder.create(ApResolver.getRandomAccesspoint(), conf());
+            connect();
+            authenticatePartial(Authentication.LoginCredentials.newBuilder().setUsername(apWelcome.getCanonicalUsername()).setTyp(apWelcome.getReusableAuthCredentialsType())
+                    .setAuthData(apWelcome.getReusableAuthCredentials()).build(), true);
+
+            LOGGER.info(String.format("Re-authenticated as %s!", apWelcome.getCanonicalUsername()));
+
+            synchronized (reconnectionListeners) {
+                reconnectionListeners.forEach(ReconnectionListener::onConnectionEstablished);
+            }
+        } catch (IOException | GeneralSecurityException | SpotifyAuthenticationException ex) {
+            conn = null;
+            LOGGER.error("Failed reconnecting, retrying in 10 seconds...", ex);
+            scheduler.schedule(this::reconnect, 10, TimeUnit.SECONDS);
+        }
+    }
+
+    @NotNull
+    public AbsConfiguration conf() {
+        return inner.configuration;
+    }
+
+    @Nullable
+    public String countryCode() {
+        return countryCode;
+    }
+
+    public void addCloseListener(@NotNull CloseListener listener) {
+        if (!closeListeners.contains(listener))
+            closeListeners.add(listener);
+    }
+
+    public void addReconnectionListener(@NotNull ReconnectionListener listener) {
+        if (!reconnectionListeners.contains(listener))
+            reconnectionListeners.add(listener);
+    }
+
+    private void parseProductInfo(@NotNull InputStream in) throws IOException, SAXException, ParserConfigurationException {
+        DocumentBuilder dBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        Document doc = dBuilder.parse(in);
+
+        Node products = doc.getElementsByTagName("products").item(0);
+        if (products == null) return;
+
+        Node product = products.getChildNodes().item(0);
+        if (product == null) return;
+
+        NodeList properties = product.getChildNodes();
+        for (int i = 0; i < properties.getLength(); i++) {
+            Node node = properties.item(i);
+            userAttributes.put(node.getNodeName(), node.getTextContent());
+        }
+
+        LOGGER.trace("Parsed product info: " + userAttributes);
+    }
+
+    @Nullable
+    public String getUserAttribute(@NotNull String key) {
+        return userAttributes.get(key);
+    }
+
+    @Contract("_, !null -> !null")
+    public String getUserAttribute(@NotNull String key, @NotNull String fallback) {
+        return userAttributes.getOrDefault(key, fallback);
+    }
+
+    @Override
+    public void event(@NotNull MercuryClient.Response resp) {
+        if (resp.uri.equals("spotify:user:attributes:update")) {
+            UserAttributesUpdate attributesUpdate;
+            try {
+                attributesUpdate = UserAttributesUpdate.parseFrom(resp.payload.stream());
+            } catch (IOException ex) {
+                LOGGER.warn("Failed parsing user attributes update.", ex);
+                return;
+            }
+
+            for (ExplicitContentPubsub.KeyValuePair pair : attributesUpdate.getPairsList()) {
+                userAttributes.put(pair.getKey(), pair.getValue());
+                LOGGER.trace(String.format("Updated user attribute: %s -> %s", pair.getKey(), pair.getValue()));
+            }
+        }
+    }
+
+    public interface ReconnectionListener {
+        void onConnectionDropped();
+
+        void onConnectionEstablished();
+    }
+
+    public interface ProxyConfiguration {
+        boolean proxyEnabled();
+
+        @NotNull Proxy.Type proxyType();
+
+        @NotNull String proxyAddress();
+
+        int proxyPort();
+
+        boolean proxyAuth();
+
+        @NotNull String proxyUsername();
+
+        @NotNull String proxyPassword();
+    }
+
+    public interface CloseListener {
+        void onClosed();
+    }
+
+    static class Inner {
+        final Connect.DeviceType deviceType;
+        final String deviceName;
+        final SecureRandom random;
+        final String deviceId;
+        final AbsConfiguration configuration;
+
+        private Inner(Connect.DeviceType deviceType, String deviceName, AbsConfiguration configuration) {
+            this.deviceType = deviceType;
+            this.deviceName = deviceName;
+            this.configuration = configuration;
+            this.random = new SecureRandom();
+
+            String configuredDeviceId = configuration.deviceId();
+            this.deviceId = (configuredDeviceId == null || configuredDeviceId.isEmpty()) ? Utils.randomHexString(random, 40).toLowerCase() : configuredDeviceId;
+        }
+
+        @NotNull
+        static Inner from(@NotNull AbsConfiguration configuration) {
+            String deviceName = configuration.deviceName();
+            if (deviceName == null || deviceName.isEmpty())
+                throw new IllegalArgumentException("Device name required: " + deviceName);
+
+            Connect.DeviceType deviceType = configuration.deviceType();
+            if (deviceType == null)
+                throw new IllegalArgumentException("Device type required!");
+
+            return new Inner(deviceType, deviceName, configuration);
+        }
+
+        @NotNull Authentication.LoginCredentials decryptBlob(String username, byte[] encryptedBlob) throws GeneralSecurityException, IOException {
+            encryptedBlob = Base64.getDecoder().decode(encryptedBlob);
+
+            byte[] secret = MessageDigest.getInstance("SHA-1").digest(deviceId.getBytes());
+            byte[] baseKey = PBKDF2.HmacSHA1(secret, username.getBytes(), 0x100, 20);
+
+            byte[] key = ByteBuffer.allocate(24).put(MessageDigest.getInstance("SHA-1").digest(baseKey)).putInt(20).array();
+
+            Cipher aes = Cipher.getInstance("AES/ECB/NoPadding");
+            aes.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"));
+            byte[] decryptedBlob = aes.doFinal(encryptedBlob);
+
+            int l = decryptedBlob.length;
+            for (int i = 0; i < l - 0x10; i++)
+                decryptedBlob[l - i - 1] ^= decryptedBlob[l - i - 0x11];
+
+            ByteBuffer blob = ByteBuffer.wrap(decryptedBlob);
+            blob.get();
+            int len = readBlobInt(blob);
+            blob.get(new byte[len]);
+            blob.get();
+
+            int typeInt = readBlobInt(blob);
+            Authentication.AuthenticationType type = Authentication.AuthenticationType.forNumber(typeInt);
+            if (type == null)
+                throw new IOException(new IllegalArgumentException("Unknown AuthenticationType: " + typeInt));
+
+            blob.get();
+
+            len = readBlobInt(blob);
+            byte[] authData = new byte[len];
+            blob.get(authData);
+
+            return Authentication.LoginCredentials.newBuilder().setUsername(username).setTyp(type).setAuthData(ByteString.copyFrom(authData)).build();
+        }
+    }
+
+    /**
+     * Builder for setting up a {@link Session} object.
+     */
+    public static class Builder {
+        private final Inner inner;
+        private final AuthConfiguration authConf;
+        private Authentication.LoginCredentials loginCredentials = null;
+
+        public Builder(@NotNull Connect.DeviceType deviceType, @NotNull String deviceName, @NotNull AbsConfiguration configuration) {
+            this.inner = new Inner(deviceType, deviceName, configuration);
+            this.authConf = configuration;
+        }
+
+        public Builder(@NotNull AbsConfiguration configuration) {
+            this.inner = Inner.from(configuration);
+            this.authConf = configuration;
+        }
+
+        /**
+         * Authenticate with your Facebook account, will prompt to open a link in the browser.
+         */
+        @NotNull
+        public Builder facebook() throws IOException {
+            try (FacebookAuthenticator authenticator = new FacebookAuthenticator()) {
+                loginCredentials = authenticator.lockUntilCredentials();
+                return this;
+            } catch (InterruptedException ex) {
+                throw new IOException(ex);
+            }
+        }
+
+        /**
+         * Authenticate with a saved credentials blob.
+         *
+         * @param username Your Spotify username
+         * @param blob     The Base64-decoded blob
+         */
+        @NotNull
+        public Builder blob(String username, byte[] blob) throws GeneralSecurityException, IOException {
+            loginCredentials = inner.decryptBlob(username, blob);
+            return this;
+        }
+
+        /**
+         * Authenticate with username and password. The credentials won't be saved.
+         *
+         * @param username Your Spotify username
+         * @param password Your Spotify password
+         */
+        @NotNull
+        public Builder userPass(@NotNull String username, @NotNull String password) {
+            loginCredentials = Authentication.LoginCredentials.newBuilder().setUsername(username).setTyp(Authentication.AuthenticationType.AUTHENTICATION_USER_PASS)
+                    .setAuthData(ByteString.copyFromUtf8(password)).build();
+            return this;
+        }
+
+        /**
+         * Creates a connected and fully authenticated {@link Session} object.
+         */
+        @NotNull
+        public Session create() throws IOException, GeneralSecurityException, SpotifyAuthenticationException, MercuryClient.MercuryException {
+            if (authConf.storeCredentials()) {
+                File storeFile = authConf.credentialsFile();
+                if (storeFile != null && storeFile.exists()) {
+                    JsonObject obj = JsonParser.parseReader(new FileReader(storeFile)).getAsJsonObject();
+                    loginCredentials = Authentication.LoginCredentials.newBuilder().setTyp(Authentication.AuthenticationType.valueOf(obj.get("type").getAsString()))
+                            .setUsername(obj.get("username").getAsString()).setAuthData(Utils.fromBase64(obj.get("credentials").getAsString())).build();
+                }
+            }
+
+            if (loginCredentials == null) {
+                String blob = authConf.authBlob();
+                String username = authConf.authUsername();
+                String password = authConf.authPassword();
+
+                switch (authConf.authStrategy()) {
+                    case FACEBOOK:
+                        facebook();
+                        break;
+                    case BLOB:
+                        if (username == null)
+                            throw new IllegalArgumentException("Missing authUsername!");
+                        if (blob == null)
+                            throw new IllegalArgumentException("Missing authBlob!");
+                        blob(username, Base64.getDecoder().decode(blob));
+                        break;
+                    case USER_PASS:
+                        if (username == null)
+                            throw new IllegalArgumentException("Missing authUsername!");
+                        if (password == null)
+                            throw new IllegalArgumentException("Missing authPassword!");
+                        userPass(username, password);
+                        break;
+                    case ZEROCONF:
+                        throw new IllegalStateException("Cannot handle ZEROCONF! Use ZeroconfServer.");
+                    default:
+                        throw new IllegalStateException("Unknown auth authStrategy: " + authConf.authStrategy());
+                }
+            }
+
+            Session session = Session.from(inner);
+            session.connect();
+            session.authenticate(loginCredentials);
+            return session;
+        }
+    }
+
+    public static class SpotifyAuthenticationException extends Exception {
+        private SpotifyAuthenticationException(Keyexchange.APLoginFailed loginFailed) {
+            super(loginFailed.getErrorCode().name());
+        }
+    }
+
+    private static class Accumulator extends DataOutputStream {
+        private byte[] bytes;
+
+        Accumulator() {
+            super(new ByteArrayOutputStream());
+        }
+
+        void dump() throws IOException {
+            bytes = ((ByteArrayOutputStream) this.out).toByteArray();
+            this.close();
+        }
+
+        @NotNull byte[] array() {
+            return bytes;
+        }
+    }
+
+    private static class ConnectionHolder {
+        final Socket socket;
+        final DataInputStream in;
+        final DataOutputStream out;
+
+        private ConnectionHolder(@NotNull Socket socket) throws IOException {
+            this.socket = socket;
+            this.in = new DataInputStream(socket.getInputStream());
+            this.out = new DataOutputStream(socket.getOutputStream());
+        }
+
+        @NotNull
+        static ConnectionHolder create(@NotNull String addr, @NotNull ProxyConfiguration conf) throws IOException {
+            int colon = addr.indexOf(':');
+            String apAddr = addr.substring(0, colon);
+            int apPort = Integer.parseInt(addr.substring(colon + 1));
+            if (!conf.proxyEnabled() || conf.proxyType() == Proxy.Type.DIRECT)
+                return new ConnectionHolder(new Socket(apAddr, apPort));
+
+            switch (conf.proxyType()) {
+                case HTTP:
+                    Socket sock = new Socket(conf.proxyAddress(), conf.proxyPort());
+                    OutputStream out = sock.getOutputStream();
+                    DataInputStream in = new DataInputStream(sock.getInputStream());
+
+                    out.write(String.format("CONNECT %s:%d HTTP/1.0\n", apAddr, apPort).getBytes());
+                    if (conf.proxyAuth()) {
+                        out.write("Proxy-Authorization: Basic ".getBytes());
+                        out.write(Base64.getEncoder().encodeToString(String.format("%s:%s\n", conf.proxyUsername(), conf.proxyPassword()).getBytes()).getBytes());
+                    }
+
+                    out.write('\n');
+                    out.flush();
+
+                    String sl = Utils.readLine(in);
+                    if (!sl.contains("200"))
+                        throw new IOException("Failed connecting: " + sl);
+
+                    //noinspection StatementWithEmptyBody
+                    while (!Utils.readLine(in).isEmpty()) {
+                        // Read all headers
+                    }
+
+                    LOGGER.info("Successfully connected to the HTTP proxy.");
+                    return new ConnectionHolder(sock);
+                case SOCKS:
+                    if (conf.proxyAuth()) {
+                        java.net.Authenticator.setDefault(new java.net.Authenticator() {
+                            final String username = conf.proxyUsername();
+                            final String password = conf.proxyPassword();
+
+                            @Override
+                            protected PasswordAuthentication getPasswordAuthentication() {
+                                if (Objects.equals(getRequestingProtocol(), "SOCKS5") && Objects.equals(getRequestingPrompt(), "SOCKS authentication"))
+                                    return new PasswordAuthentication(username, password.toCharArray());
+
+                                return super.getPasswordAuthentication();
+                            }
+                        });
+                    }
+
+                    Proxy proxy = new Proxy(conf.proxyType(), new InetSocketAddress(conf.proxyAddress(), conf.proxyPort()));
+                    Socket proxySocket = new Socket(proxy);
+                    proxySocket.connect(new InetSocketAddress(apAddr, apPort));
+                    LOGGER.info("Successfully connected to the SOCKS proxy.");
+                    return new ConnectionHolder(proxySocket);
+                case DIRECT:
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+    }
+
+    private class Receiver implements Runnable {
+        private volatile boolean shouldStop = false;
+        private Thread thread;
+
+        private Receiver() {
+        }
+
+        void stop() {
+            shouldStop = true;
+            thread.interrupt();
+        }
+
+        @Override
+        public void run() {
+            LOGGER.trace("Session.Receiver started");
+            this.thread = Thread.currentThread();
+            while (!shouldStop) {
+                Packet packet;
+                Packet.Type cmd;
+                try {
+                    packet = cipherPair.receiveEncoded(conn.in);
+                    cmd = Packet.Type.parse(packet.cmd);
+                    if (cmd == null) {
+                        LOGGER.info(String.format("Skipping unknown command {cmd: 0x%s, payload: %s}", Integer.toHexString(packet.cmd), Utils.bytesToHex(packet.payload)));
+                        continue;
+                    }
+                } catch (IOException | GeneralSecurityException ex) {
+                    if (!shouldStop) {
+                        LOGGER.fatal("Failed reading packet!", ex);
+                        reconnect();
+                    }
+
+                    break;
+                }
+
+                if (shouldStop) break;
+
+                switch (cmd) {
+                    case Ping:
+                        if (scheduledReconnect != null)
+                            scheduledReconnect.cancel(true);
+                        scheduledReconnect = scheduler.schedule(() -> {
+                            LOGGER.warn("Socket timed out. Reconnecting...");
+                            reconnect();
+                        }, 2 * 60 + 5, TimeUnit.SECONDS);
+
+                        TimeProvider.updateWithPing(packet.payload);
+
+                        try {
+                            send(Packet.Type.Pong, packet.payload);
+                        } catch (IOException ex) {
+                            LOGGER.fatal("Failed sending Pong!", ex);
+                        }
+                        break;
+                    case PongAck:
+                        // Silent
+                        break;
+                    case CountryCode:
+                        countryCode = new String(packet.payload);
+                        LOGGER.info("Received CountryCode: " + countryCode);
+                        break;
+                    case LicenseVersion:
+                        ByteBuffer licenseVersion = ByteBuffer.wrap(packet.payload);
+                        short id = licenseVersion.getShort();
+                        if (id != 0) {
+                            byte[] buffer = new byte[licenseVersion.get()];
+                            licenseVersion.get(buffer);
+                            LOGGER.info(String.format("Received LicenseVersion: %d, %s", id, new String(buffer)));
+                        } else {
+                            LOGGER.info(String.format("Received LicenseVersion: %d", id));
+                        }
+                        break;
+                    case Unknown_0x10:
+                        LOGGER.debug("Received 0x10: " + Utils.bytesToHex(packet.payload));
+                        break;
+                    case MercurySub:
+                    case MercuryUnsub:
+                    case MercuryEvent:
+                    case MercuryReq:
+                        mercury().dispatch(packet);
+                        break;
+                    case AesKey:
+                    case AesKeyError:
+                        audioKey().dispatch(packet);
+                        break;
+                    case ChannelError:
+                    case StreamChunkRes:
+                        channel().dispatch(packet);
                         break;
                     case ProductInfo:
                         try {
@@ -1086,14 +1086,14 @@ public final class Session implements Closeable, SubListener {
                         } catch (IOException | ParserConfigurationException | SAXException ex) {
                             LOGGER.warn("Failed parsing prodcut info!", ex);
                         }
-						break;
-					default:
-						LOGGER.info("Skipping " + cmd.name());
-						break;
-				}
-			}
+                        break;
+                    default:
+                        LOGGER.info("Skipping " + cmd.name());
+                        break;
+                }
+            }
 
-			LOGGER.trace("Session.Receiver stopped");
-		}
-	}
+            LOGGER.trace("Session.Receiver stopped");
+        }
+    }
 }

--- a/core/src/main/java/xyz/gianlu/librespot/core/Session.java
+++ b/core/src/main/java/xyz/gianlu/librespot/core/Session.java
@@ -57,397 +57,383 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @author Gianlu
  */
 public final class Session implements Closeable, SubListener {
-    private static final Logger LOGGER = Logger.getLogger(Session.class);
-    private static final byte[] serverKey = new byte[]{
-            (byte) 0xac, (byte) 0xe0, (byte) 0x46, (byte) 0x0b, (byte) 0xff, (byte) 0xc2, (byte) 0x30, (byte) 0xaf, (byte) 0xf4, (byte) 0x6b, (byte) 0xfe, (byte) 0xc3,
-            (byte) 0xbf, (byte) 0xbf, (byte) 0x86, (byte) 0x3d, (byte) 0xa1, (byte) 0x91, (byte) 0xc6, (byte) 0xcc, (byte) 0x33, (byte) 0x6c, (byte) 0x93, (byte) 0xa1,
-            (byte) 0x4f, (byte) 0xb3, (byte) 0xb0, (byte) 0x16, (byte) 0x12, (byte) 0xac, (byte) 0xac, (byte) 0x6a, (byte) 0xf1, (byte) 0x80, (byte) 0xe7, (byte) 0xf6,
-            (byte) 0x14, (byte) 0xd9, (byte) 0x42, (byte) 0x9d, (byte) 0xbe, (byte) 0x2e, (byte) 0x34, (byte) 0x66, (byte) 0x43, (byte) 0xe3, (byte) 0x62, (byte) 0xd2,
-            (byte) 0x32, (byte) 0x7a, (byte) 0x1a, (byte) 0x0d, (byte) 0x92, (byte) 0x3b, (byte) 0xae, (byte) 0xdd, (byte) 0x14, (byte) 0x02, (byte) 0xb1, (byte) 0x81,
-            (byte) 0x55, (byte) 0x05, (byte) 0x61, (byte) 0x04, (byte) 0xd5, (byte) 0x2c, (byte) 0x96, (byte) 0xa4, (byte) 0x4c, (byte) 0x1e, (byte) 0xcc, (byte) 0x02,
-            (byte) 0x4a, (byte) 0xd4, (byte) 0xb2, (byte) 0x0c, (byte) 0x00, (byte) 0x1f, (byte) 0x17, (byte) 0xed, (byte) 0xc2, (byte) 0x2f, (byte) 0xc4, (byte) 0x35,
-            (byte) 0x21, (byte) 0xc8, (byte) 0xf0, (byte) 0xcb, (byte) 0xae, (byte) 0xd2, (byte) 0xad, (byte) 0xd7, (byte) 0x2b, (byte) 0x0f, (byte) 0x9d, (byte) 0xb3,
-            (byte) 0xc5, (byte) 0x32, (byte) 0x1a, (byte) 0x2a, (byte) 0xfe, (byte) 0x59, (byte) 0xf3, (byte) 0x5a, (byte) 0x0d, (byte) 0xac, (byte) 0x68, (byte) 0xf1,
-            (byte) 0xfa, (byte) 0x62, (byte) 0x1e, (byte) 0xfb, (byte) 0x2c, (byte) 0x8d, (byte) 0x0c, (byte) 0xb7, (byte) 0x39, (byte) 0x2d, (byte) 0x92, (byte) 0x47,
-            (byte) 0xe3, (byte) 0xd7, (byte) 0x35, (byte) 0x1a, (byte) 0x6d, (byte) 0xbd, (byte) 0x24, (byte) 0xc2, (byte) 0xae, (byte) 0x25, (byte) 0x5b, (byte) 0x88,
-            (byte) 0xff, (byte) 0xab, (byte) 0x73, (byte) 0x29, (byte) 0x8a, (byte) 0x0b, (byte) 0xcc, (byte) 0xcd, (byte) 0x0c, (byte) 0x58, (byte) 0x67, (byte) 0x31,
-            (byte) 0x89, (byte) 0xe8, (byte) 0xbd, (byte) 0x34, (byte) 0x80, (byte) 0x78, (byte) 0x4a, (byte) 0x5f, (byte) 0xc9, (byte) 0x6b, (byte) 0x89, (byte) 0x9d,
-            (byte) 0x95, (byte) 0x6b, (byte) 0xfc, (byte) 0x86, (byte) 0xd7, (byte) 0x4f, (byte) 0x33, (byte) 0xa6, (byte) 0x78, (byte) 0x17, (byte) 0x96, (byte) 0xc9,
-            (byte) 0xc3, (byte) 0x2d, (byte) 0x0d, (byte) 0x32, (byte) 0xa5, (byte) 0xab, (byte) 0xcd, (byte) 0x05, (byte) 0x27, (byte) 0xe2, (byte) 0xf7, (byte) 0x10,
-            (byte) 0xa3, (byte) 0x96, (byte) 0x13, (byte) 0xc4, (byte) 0x2f, (byte) 0x99, (byte) 0xc0, (byte) 0x27, (byte) 0xbf, (byte) 0xed, (byte) 0x04, (byte) 0x9c,
-            (byte) 0x3c, (byte) 0x27, (byte) 0x58, (byte) 0x04, (byte) 0xb6, (byte) 0xb2, (byte) 0x19, (byte) 0xf9, (byte) 0xc1, (byte) 0x2f, (byte) 0x02, (byte) 0xe9,
-            (byte) 0x48, (byte) 0x63, (byte) 0xec, (byte) 0xa1, (byte) 0xb6, (byte) 0x42, (byte) 0xa0, (byte) 0x9d, (byte) 0x48, (byte) 0x25, (byte) 0xf8, (byte) 0xb3,
-            (byte) 0x9d, (byte) 0xd0, (byte) 0xe8, (byte) 0x6a, (byte) 0xf9, (byte) 0x48, (byte) 0x4d, (byte) 0xa1, (byte) 0xc2, (byte) 0xba, (byte) 0x86, (byte) 0x30,
-            (byte) 0x42, (byte) 0xea, (byte) 0x9d, (byte) 0xb3, (byte) 0x08, (byte) 0x6c, (byte) 0x19, (byte) 0x0e, (byte) 0x48, (byte) 0xb3, (byte) 0x9d, (byte) 0x66,
-            (byte) 0xeb, (byte) 0x00, (byte) 0x06, (byte) 0xa2, (byte) 0x5a, (byte) 0xee, (byte) 0xa1, (byte) 0x1b, (byte) 0x13, (byte) 0x87, (byte) 0x3c, (byte) 0xd7,
-            (byte) 0x19, (byte) 0xe6, (byte) 0x55, (byte) 0xbd
-    };
-    private final DiffieHellman keys;
-    private final Inner inner;
-    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(new NameThreadFactory(r -> "session-scheduler-" + r.hashCode()));
-    private final ExecutorService executorService = Executors.newCachedThreadPool(new NameThreadFactory(r -> "handle-packet-" + r.hashCode()));
-    private final AtomicBoolean authLock = new AtomicBoolean(false);
-    private final OkHttpClient client;
-    private final List<CloseListener> closeListeners = Collections.synchronizedList(new ArrayList<>());
-    private final List<ReconnectionListener> reconnectionListeners = Collections.synchronizedList(new ArrayList<>());
+	private static final Logger LOGGER = Logger.getLogger(Session.class);
+	private static final byte[] serverKey = new byte[] {(byte) 0xac, (byte) 0xe0, (byte) 0x46, (byte) 0x0b, (byte) 0xff, (byte) 0xc2, (byte) 0x30, (byte) 0xaf, (byte) 0xf4, (byte) 0x6b,
+			(byte) 0xfe, (byte) 0xc3, (byte) 0xbf, (byte) 0xbf, (byte) 0x86, (byte) 0x3d, (byte) 0xa1, (byte) 0x91, (byte) 0xc6, (byte) 0xcc, (byte) 0x33, (byte) 0x6c, (byte) 0x93,
+			(byte) 0xa1, (byte) 0x4f, (byte) 0xb3, (byte) 0xb0, (byte) 0x16, (byte) 0x12, (byte) 0xac, (byte) 0xac, (byte) 0x6a, (byte) 0xf1, (byte) 0x80, (byte) 0xe7, (byte) 0xf6,
+			(byte) 0x14, (byte) 0xd9, (byte) 0x42, (byte) 0x9d, (byte) 0xbe, (byte) 0x2e, (byte) 0x34, (byte) 0x66, (byte) 0x43, (byte) 0xe3, (byte) 0x62, (byte) 0xd2, (byte) 0x32,
+			(byte) 0x7a, (byte) 0x1a, (byte) 0x0d, (byte) 0x92, (byte) 0x3b, (byte) 0xae, (byte) 0xdd, (byte) 0x14, (byte) 0x02, (byte) 0xb1, (byte) 0x81, (byte) 0x55, (byte) 0x05,
+			(byte) 0x61, (byte) 0x04, (byte) 0xd5, (byte) 0x2c, (byte) 0x96, (byte) 0xa4, (byte) 0x4c, (byte) 0x1e, (byte) 0xcc, (byte) 0x02, (byte) 0x4a, (byte) 0xd4, (byte) 0xb2,
+			(byte) 0x0c, (byte) 0x00, (byte) 0x1f, (byte) 0x17, (byte) 0xed, (byte) 0xc2, (byte) 0x2f, (byte) 0xc4, (byte) 0x35, (byte) 0x21, (byte) 0xc8, (byte) 0xf0, (byte) 0xcb,
+			(byte) 0xae, (byte) 0xd2, (byte) 0xad, (byte) 0xd7, (byte) 0x2b, (byte) 0x0f, (byte) 0x9d, (byte) 0xb3, (byte) 0xc5, (byte) 0x32, (byte) 0x1a, (byte) 0x2a, (byte) 0xfe,
+			(byte) 0x59, (byte) 0xf3, (byte) 0x5a, (byte) 0x0d, (byte) 0xac, (byte) 0x68, (byte) 0xf1, (byte) 0xfa, (byte) 0x62, (byte) 0x1e, (byte) 0xfb, (byte) 0x2c, (byte) 0x8d,
+			(byte) 0x0c, (byte) 0xb7, (byte) 0x39, (byte) 0x2d, (byte) 0x92, (byte) 0x47, (byte) 0xe3, (byte) 0xd7, (byte) 0x35, (byte) 0x1a, (byte) 0x6d, (byte) 0xbd, (byte) 0x24,
+			(byte) 0xc2, (byte) 0xae, (byte) 0x25, (byte) 0x5b, (byte) 0x88, (byte) 0xff, (byte) 0xab, (byte) 0x73, (byte) 0x29, (byte) 0x8a, (byte) 0x0b, (byte) 0xcc, (byte) 0xcd,
+			(byte) 0x0c, (byte) 0x58, (byte) 0x67, (byte) 0x31, (byte) 0x89, (byte) 0xe8, (byte) 0xbd, (byte) 0x34, (byte) 0x80, (byte) 0x78, (byte) 0x4a, (byte) 0x5f, (byte) 0xc9,
+			(byte) 0x6b, (byte) 0x89, (byte) 0x9d, (byte) 0x95, (byte) 0x6b, (byte) 0xfc, (byte) 0x86, (byte) 0xd7, (byte) 0x4f, (byte) 0x33, (byte) 0xa6, (byte) 0x78, (byte) 0x17,
+			(byte) 0x96, (byte) 0xc9, (byte) 0xc3, (byte) 0x2d, (byte) 0x0d, (byte) 0x32, (byte) 0xa5, (byte) 0xab, (byte) 0xcd, (byte) 0x05, (byte) 0x27, (byte) 0xe2, (byte) 0xf7,
+			(byte) 0x10, (byte) 0xa3, (byte) 0x96, (byte) 0x13, (byte) 0xc4, (byte) 0x2f, (byte) 0x99, (byte) 0xc0, (byte) 0x27, (byte) 0xbf, (byte) 0xed, (byte) 0x04, (byte) 0x9c,
+			(byte) 0x3c, (byte) 0x27, (byte) 0x58, (byte) 0x04, (byte) 0xb6, (byte) 0xb2, (byte) 0x19, (byte) 0xf9, (byte) 0xc1, (byte) 0x2f, (byte) 0x02, (byte) 0xe9, (byte) 0x48,
+			(byte) 0x63, (byte) 0xec, (byte) 0xa1, (byte) 0xb6, (byte) 0x42, (byte) 0xa0, (byte) 0x9d, (byte) 0x48, (byte) 0x25, (byte) 0xf8, (byte) 0xb3, (byte) 0x9d, (byte) 0xd0,
+			(byte) 0xe8, (byte) 0x6a, (byte) 0xf9, (byte) 0x48, (byte) 0x4d, (byte) 0xa1, (byte) 0xc2, (byte) 0xba, (byte) 0x86, (byte) 0x30, (byte) 0x42, (byte) 0xea, (byte) 0x9d,
+			(byte) 0xb3, (byte) 0x08, (byte) 0x6c, (byte) 0x19, (byte) 0x0e, (byte) 0x48, (byte) 0xb3, (byte) 0x9d, (byte) 0x66, (byte) 0xeb, (byte) 0x00, (byte) 0x06, (byte) 0xa2,
+			(byte) 0x5a, (byte) 0xee, (byte) 0xa1, (byte) 0x1b, (byte) 0x13, (byte) 0x87, (byte) 0x3c, (byte) 0xd7, (byte) 0x19, (byte) 0xe6, (byte) 0x55, (byte) 0xbd};
+	private final DiffieHellman keys;
+	private final Inner inner;
+	private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(new NameThreadFactory(r -> "session-scheduler-" + r.hashCode()));
+	private final ExecutorService executorService = Executors.newCachedThreadPool(new NameThreadFactory(r -> "handle-packet-" + r.hashCode()));
+	private final AtomicBoolean authLock = new AtomicBoolean(false);
+	private final OkHttpClient client;
+	private final List<CloseListener> closeListeners = Collections.synchronizedList(new ArrayList<>());
+	private final List<ReconnectionListener> reconnectionListeners = Collections.synchronizedList(new ArrayList<>());
     private final Map<String, String> userAttributes = Collections.synchronizedMap(new HashMap<>());
-    private ConnectionHolder conn;
+	private ConnectionHolder conn;
     private volatile CipherPair cipherPair;
-    private Receiver receiver;
-    private Authentication.APWelcome apWelcome = null;
-    private MercuryClient mercuryClient;
-    private Player player;
-    private AudioKeyManager audioKeyManager;
-    private ChannelManager channelManager;
-    private TokenProvider tokenProvider;
-    private CdnManager cdnManager;
-    private CacheManager cacheManager;
-    private DealerClient dealer;
-    private ApiClient api;
-    private SearchManager search;
-    private PlayableContentFeeder contentFeeder;
-    private String countryCode = null;
-    private volatile boolean closed = false;
-    private volatile ScheduledFuture<?> scheduledReconnect = null;
+	private Receiver receiver;
+	private Authentication.APWelcome apWelcome = null;
+	private MercuryClient mercuryClient;
+	private Player player;
+	private AudioKeyManager audioKeyManager;
+	private ChannelManager channelManager;
+	private TokenProvider tokenProvider;
+	private CdnManager cdnManager;
+	private CacheManager cacheManager;
+	private DealerClient dealer;
+	private ApiClient api;
+	private SearchManager search;
+	private PlayableContentFeeder contentFeeder;
+	private String countryCode = null;
+	private volatile boolean closed = false;
+	private volatile ScheduledFuture<?> scheduledReconnect = null;
 
-    private Session(Inner inner, String addr) throws IOException {
-        this.inner = inner;
-        this.keys = new DiffieHellman(inner.random);
-        this.conn = ConnectionHolder.create(addr, inner.configuration);
-        this.client = createClient(inner.configuration);
+	private Session(Inner inner, String addr) throws IOException {
+		this.inner = inner;
+		this.keys = new DiffieHellman(inner.random);
+		this.conn = ConnectionHolder.create(addr, inner.configuration);
+		this.client = createClient(inner.configuration);
 
-        LOGGER.info(String.format("Created new session! {deviceId: %s, ap: %s, proxy: %b} ", inner.deviceId, addr, inner.configuration.proxyEnabled()));
-    }
+		LOGGER.info(String.format("Created new session! {deviceId: %s, ap: %s, proxy: %b} ", inner.deviceId, addr, inner.configuration.proxyEnabled()));
+	}
 
-    @NotNull
-    private static OkHttpClient createClient(@NotNull ProxyConfiguration conf) {
-        OkHttpClient.Builder builder = new OkHttpClient.Builder();
-        builder.retryOnConnectionFailure(true);
+	@NotNull
+	private static OkHttpClient createClient(@NotNull ProxyConfiguration conf) {
+		OkHttpClient.Builder builder = new OkHttpClient.Builder();
+		builder.retryOnConnectionFailure(true);
 
-        if (conf.proxyEnabled() && conf.proxyType() != Proxy.Type.DIRECT) {
-            builder.proxy(new Proxy(conf.proxyType(), new InetSocketAddress(conf.proxyAddress(), conf.proxyPort())));
-            if (conf.proxyAuth()) {
-                builder.proxyAuthenticator(new Authenticator() {
-                    final String username = conf.proxyUsername();
-                    final String password = conf.proxyPassword();
+		if (conf.proxyEnabled() && conf.proxyType() != Proxy.Type.DIRECT) {
+			builder.proxy(new Proxy(conf.proxyType(), new InetSocketAddress(conf.proxyAddress(), conf.proxyPort())));
+			if (conf.proxyAuth()) {
+				builder.proxyAuthenticator(new Authenticator() {
+					final String username = conf.proxyUsername();
+					final String password = conf.proxyPassword();
 
-                    @Override
-                    public Request authenticate(Route route, @NotNull Response response) {
-                        String credential = Credentials.basic(username, password);
-                        return response.request().newBuilder()
-                                .header("Proxy-Authorization", credential)
-                                .build();
-                    }
-                });
-            }
-        }
+					@Override
+					public Request authenticate(Route route, @NotNull Response response) {
+						String credential = Credentials.basic(username, password);
+						return response.request().newBuilder().header("Proxy-Authorization", credential).build();
+					}
+				});
+			}
+		}
 
-        return builder.build();
-    }
+		return builder.build();
+	}
 
-    private static int readBlobInt(ByteBuffer buffer) {
-        int lo = buffer.get();
-        if ((lo & 0x80) == 0) return lo;
-        int hi = buffer.get();
-        return lo & 0x7f | hi << 7;
-    }
+	private static int readBlobInt(ByteBuffer buffer) {
+		int lo = buffer.get();
+		if ((lo & 0x80) == 0)
+			return lo;
+		int hi = buffer.get();
+		return lo & 0x7f | hi << 7;
+	}
 
-    @NotNull
-    static Session from(@NotNull Inner inner) throws IOException {
-        ApResolver.fillPool();
-        TimeProvider.init(inner.configuration);
-        return new Session(inner, ApResolver.getRandomAccesspoint());
-    }
+	@NotNull
+	static Session from(@NotNull Inner inner) throws IOException {
+		ApResolver.fillPool();
+		TimeProvider.init(inner.configuration);
+		return new Session(inner, ApResolver.getRandomAccesspoint());
+	}
 
-    @NotNull
-    public OkHttpClient client() {
-        return client;
-    }
+	@NotNull
+	public OkHttpClient client() {
+		return client;
+	}
 
-    void connect() throws IOException, GeneralSecurityException, SpotifyAuthenticationException {
-        Accumulator acc = new Accumulator();
+	void connect() throws IOException, GeneralSecurityException, SpotifyAuthenticationException {
+		Accumulator acc = new Accumulator();
 
-        // Send ClientHello
+		// Send ClientHello
 
-        byte[] nonce = new byte[0x10];
-        inner.random.nextBytes(nonce);
+		byte[] nonce = new byte[0x10];
+		inner.random.nextBytes(nonce);
 
-        Keyexchange.ClientHello clientHello = Keyexchange.ClientHello.newBuilder()
-                .setBuildInfo(Version.standardBuildInfo())
-                .addCryptosuitesSupported(Keyexchange.Cryptosuite.CRYPTO_SUITE_SHANNON)
-                .setLoginCryptoHello(Keyexchange.LoginCryptoHelloUnion.newBuilder()
-                        .setDiffieHellman(Keyexchange.LoginCryptoDiffieHellmanHello.newBuilder()
-                                .setGc(ByteString.copyFrom(keys.publicKeyArray()))
-                                .setServerKeysKnown(1)
-                                .build())
-                        .build())
-                .setClientNonce(ByteString.copyFrom(nonce))
-                .setPadding(ByteString.copyFrom(new byte[]{0x1e}))
-                .build();
+		Keyexchange.ClientHello clientHello = Keyexchange.ClientHello.newBuilder().setBuildInfo(Version.standardBuildInfo())
+				.addCryptosuitesSupported(Keyexchange.Cryptosuite.CRYPTO_SUITE_SHANNON).setLoginCryptoHello(Keyexchange.LoginCryptoHelloUnion.newBuilder()
+						.setDiffieHellman(Keyexchange.LoginCryptoDiffieHellmanHello.newBuilder().setGc(ByteString.copyFrom(keys.publicKeyArray())).setServerKeysKnown(1).build()).build())
+				.setClientNonce(ByteString.copyFrom(nonce)).setPadding(ByteString.copyFrom(new byte[] {0x1e})).build();
 
-        byte[] clientHelloBytes = clientHello.toByteArray();
-        int length = 2 + 4 + clientHelloBytes.length;
-        conn.out.writeByte(0);
-        conn.out.writeByte(4);
-        conn.out.writeInt(length);
-        conn.out.write(clientHelloBytes);
-        conn.out.flush();
+		byte[] clientHelloBytes = clientHello.toByteArray();
+		int length = 2 + 4 + clientHelloBytes.length;
+		conn.out.writeByte(0);
+		conn.out.writeByte(4);
+		conn.out.writeInt(length);
+		conn.out.write(clientHelloBytes);
+		conn.out.flush();
 
-        acc.writeByte(0);
-        acc.writeByte(4);
-        acc.writeInt(length);
-        acc.write(clientHelloBytes);
+		acc.writeByte(0);
+		acc.writeByte(4);
+		acc.writeInt(length);
+		acc.write(clientHelloBytes);
+
+		// Read APResponseMessage
+
+		length = conn.in.readInt();
+		acc.writeInt(length);
+		byte[] buffer = new byte[length - 4];
+		conn.in.readFully(buffer);
+		acc.write(buffer);
+		acc.dump();
+
+		Keyexchange.APResponseMessage apResponseMessage = Keyexchange.APResponseMessage.parseFrom(buffer);
+		byte[] sharedKey = Utils.toByteArray(keys.computeSharedKey(apResponseMessage.getChallenge().getLoginCryptoChallenge().getDiffieHellman().getGs().toByteArray()));
+
+		// Check gs_signature
+
+		KeyFactory factory = KeyFactory.getInstance("RSA");
+		PublicKey publicKey = factory.generatePublic(new RSAPublicKeySpec(new BigInteger(1, serverKey), BigInteger.valueOf(65537)));
+
+		Signature sig = Signature.getInstance("SHA1withRSA");
+		sig.initVerify(publicKey);
+		sig.update(apResponseMessage.getChallenge().getLoginCryptoChallenge().getDiffieHellman().getGs().toByteArray());
+		if (!sig.verify(apResponseMessage.getChallenge().getLoginCryptoChallenge().getDiffieHellman().getGsSignature().toByteArray()))
+			throw new GeneralSecurityException("Failed signature check!");
+
+		// Solve challenge
+
+		ByteArrayOutputStream data = new ByteArrayOutputStream(0x64);
+
+		Mac mac = Mac.getInstance("HmacSHA1");
+		mac.init(new SecretKeySpec(sharedKey, "HmacSHA1"));
+		for (int i = 1; i < 6; i++) {
+			mac.update(acc.array());
+			mac.update(new byte[] {(byte) i});
+			data.write(mac.doFinal());
+			mac.reset();
+		}
+
+		byte[] dataArray = data.toByteArray();
+		mac = Mac.getInstance("HmacSHA1");
+		mac.init(new SecretKeySpec(Arrays.copyOfRange(dataArray, 0, 0x14), "HmacSHA1"));
+		mac.update(acc.array());
+
+		byte[] challenge = mac.doFinal();
+		Keyexchange.ClientResponsePlaintext clientResponsePlaintext = Keyexchange.ClientResponsePlaintext.newBuilder().setLoginCryptoResponse(
+				Keyexchange.LoginCryptoResponseUnion.newBuilder().setDiffieHellman(Keyexchange.LoginCryptoDiffieHellmanResponse.newBuilder().setHmac(ByteString.copyFrom(challenge)).build())
+						.build()).setPowResponse(Keyexchange.PoWResponseUnion.newBuilder().build()).setCryptoResponse(Keyexchange.CryptoResponseUnion.newBuilder().build()).build();
+
+		byte[] clientResponsePlaintextBytes = clientResponsePlaintext.toByteArray();
+		length = 4 + clientResponsePlaintextBytes.length;
+		conn.out.writeInt(length);
+		conn.out.write(clientResponsePlaintextBytes);
+		conn.out.flush();
+
+		try {
+			byte[] scrap = new byte[4];
+			conn.socket.setSoTimeout(300);
+			int read = conn.in.read(scrap);
+			if (read == scrap.length) {
+				length = (scrap[0] << 24) | (scrap[1] << 16) | (scrap[2] << 8) | (scrap[3] & 0xFF);
+				byte[] payload = new byte[length - 4];
+				conn.in.readFully(payload);
+				Keyexchange.APLoginFailed failed = Keyexchange.APResponseMessage.parseFrom(payload).getLoginFailed();
+				throw new SpotifyAuthenticationException(failed);
+			} else if (read > 0) {
+				throw new IllegalStateException("Read unknown data!");
+			}
+		} catch (SocketTimeoutException ignored) {
+		} finally {
+			conn.socket.setSoTimeout(0);
+		}
 
 
-        // Read APResponseMessage
+		synchronized (authLock) {
+			// Init Shannon cipher
+			cipherPair = new CipherPair(Arrays.copyOfRange(data.toByteArray(), 0x14, 0x34),
+					Arrays.copyOfRange(data.toByteArray(), 0x34, 0x54));
 
-        length = conn.in.readInt();
-        acc.writeInt(length);
-        byte[] buffer = new byte[length - 4];
-        conn.in.readFully(buffer);
-        acc.write(buffer);
-        acc.dump();
+			authLock.set(true);
+		}
 
-        Keyexchange.APResponseMessage apResponseMessage = Keyexchange.APResponseMessage.parseFrom(buffer);
-        byte[] sharedKey = Utils.toByteArray(keys.computeSharedKey(apResponseMessage.getChallenge().getLoginCryptoChallenge().getDiffieHellman().getGs().toByteArray()));
+		LOGGER.info("Connected successfully!");
+	}
 
+	/**
+	 * Authenticates with the server and creates all the necessary components.
+	 * All of them should be initialized inside the synchronized block and MUST NOT call any method on this {@link Session} object.
+	 */
+	void authenticate(@NotNull Authentication.LoginCredentials credentials) throws IOException, GeneralSecurityException, SpotifyAuthenticationException, MercuryClient.MercuryException {
+		authenticatePartial(credentials, false);
 
-        // Check gs_signature
+		synchronized (authLock) {
+			mercuryClient = new MercuryClient(this);
+			tokenProvider = new TokenProvider(this);
+			audioKeyManager = new AudioKeyManager(this);
+			channelManager = new ChannelManager(this);
+			api = new ApiClient(this);
+			cdnManager = new CdnManager(this);
+			contentFeeder = new PlayableContentFeeder(this);
+			cacheManager = new CacheManager(inner.configuration);
+			dealer = new DealerClient(this);
+			player = new Player(inner.configuration, this);
+			search = new SearchManager(this);
 
-        KeyFactory factory = KeyFactory.getInstance("RSA");
-        PublicKey publicKey = factory.generatePublic(new RSAPublicKeySpec(new BigInteger(1, serverKey), BigInteger.valueOf(65537)));
+			authLock.set(false);
+			authLock.notifyAll();
+		}
 
-        Signature sig = Signature.getInstance("SHA1withRSA");
-        sig.initVerify(publicKey);
-        sig.update(apResponseMessage.getChallenge().getLoginCryptoChallenge().getDiffieHellman().getGs().toByteArray());
-        if (!sig.verify(apResponseMessage.getChallenge().getLoginCryptoChallenge().getDiffieHellman().getGsSignature().toByteArray()))
-            throw new GeneralSecurityException("Failed signature check!");
+		dealer.connect();
+		player.initState();
 
+		TimeProvider.init(this);
 
-        // Solve challenge
-
-        ByteArrayOutputStream data = new ByteArrayOutputStream(0x64);
-
-        Mac mac = Mac.getInstance("HmacSHA1");
-        mac.init(new SecretKeySpec(sharedKey, "HmacSHA1"));
-        for (int i = 1; i < 6; i++) {
-            mac.update(acc.array());
-            mac.update(new byte[]{(byte) i});
-            data.write(mac.doFinal());
-            mac.reset();
-        }
-
-        byte[] dataArray = data.toByteArray();
-        mac = Mac.getInstance("HmacSHA1");
-        mac.init(new SecretKeySpec(Arrays.copyOfRange(dataArray, 0, 0x14), "HmacSHA1"));
-        mac.update(acc.array());
-
-        byte[] challenge = mac.doFinal();
-        Keyexchange.ClientResponsePlaintext clientResponsePlaintext = Keyexchange.ClientResponsePlaintext.newBuilder()
-                .setLoginCryptoResponse(Keyexchange.LoginCryptoResponseUnion.newBuilder()
-                        .setDiffieHellman(Keyexchange.LoginCryptoDiffieHellmanResponse.newBuilder()
-                                .setHmac(ByteString.copyFrom(challenge)).build())
-                        .build())
-                .setPowResponse(Keyexchange.PoWResponseUnion.newBuilder().build())
-                .setCryptoResponse(Keyexchange.CryptoResponseUnion.newBuilder().build())
-                .build();
-
-        byte[] clientResponsePlaintextBytes = clientResponsePlaintext.toByteArray();
-        length = 4 + clientResponsePlaintextBytes.length;
-        conn.out.writeInt(length);
-        conn.out.write(clientResponsePlaintextBytes);
-        conn.out.flush();
-
-        try {
-            byte[] scrap = new byte[4];
-            conn.socket.setSoTimeout(300);
-            int read = conn.in.read(scrap);
-            if (read == scrap.length) {
-                length = (scrap[0] << 24) | (scrap[1] << 16) | (scrap[2] << 8) | (scrap[3] & 0xFF);
-                byte[] payload = new byte[length - 4];
-                conn.in.readFully(payload);
-                Keyexchange.APLoginFailed failed = Keyexchange.APResponseMessage.parseFrom(payload).getLoginFailed();
-                throw new SpotifyAuthenticationException(failed);
-            } else if (read > 0) {
-                throw new IllegalStateException("Read unknown data!");
-            }
-        } catch (SocketTimeoutException ignored) {
-        } finally {
-            conn.socket.setSoTimeout(0);
-        }
-
-        synchronized (authLock) {
-            // Init Shannon cipher
-            cipherPair = new CipherPair(Arrays.copyOfRange(data.toByteArray(), 0x14, 0x34),
-                    Arrays.copyOfRange(data.toByteArray(), 0x34, 0x54));
-
-            authLock.set(true);
-        }
-
-        LOGGER.info("Connected successfully!");
-    }
-
-    /**
-     * Authenticates with the server and creates all the necessary components.
-     * All of them should be initialized inside the synchronized block and MUST NOT call any method on this {@link Session} object.
-     */
-    void authenticate(@NotNull Authentication.LoginCredentials credentials) throws IOException, GeneralSecurityException, SpotifyAuthenticationException, MercuryClient.MercuryException {
-        authenticatePartial(credentials, false);
-
-        synchronized (authLock) {
-            mercuryClient = new MercuryClient(this);
-            tokenProvider = new TokenProvider(this);
-            audioKeyManager = new AudioKeyManager(this);
-            channelManager = new ChannelManager(this);
-            api = new ApiClient(this);
-            cdnManager = new CdnManager(this);
-            contentFeeder = new PlayableContentFeeder(this);
-            cacheManager = new CacheManager(inner.configuration);
-            dealer = new DealerClient(this);
-            player = new Player(inner.configuration, this);
-            search = new SearchManager(this);
-
-            authLock.set(false);
-            authLock.notifyAll();
-        }
-
-        dealer.connect();
-        player.initState();
-
-        TimeProvider.init(this);
-
-        LOGGER.info(String.format("Authenticated as %s!", apWelcome.getCanonicalUsername()));
+		LOGGER.info(String.format("Authenticated as %s!", apWelcome.getCanonicalUsername()));
 
 
         mercuryClient.interestedIn("spotify:user:attributes:update", this);
-    }
+	}
 
-    /**
-     * Authenticates with the server. Does not create all the components unlike {@link Session#authenticate(Authentication.LoginCredentials)}.
-     *
-     * @param removeLock Whether {@link Session#authLock} should be released or not.
-     *                   {@code false} for {@link Session#authenticate(Authentication.LoginCredentials)},
-     *                   {@code true} for {@link Session#reconnect()}.
-     */
-    private void authenticatePartial(@NotNull Authentication.LoginCredentials credentials, boolean removeLock) throws IOException, GeneralSecurityException, SpotifyAuthenticationException {
-        if (cipherPair == null) throw new IllegalStateException("Connection not established!");
+	/**
+	 * Authenticates with the server. Does not create all the components unlike {@link Session#authenticate(Authentication.LoginCredentials)}.
+	 *
+	 * @param removeLock Whether {@link Session#authLock} should be released or not.
+	 *                   {@code false} for {@link Session#authenticate(Authentication.LoginCredentials)},
+	 *                   {@code true} for {@link Session#reconnect()}.
+	 */
+	private void authenticatePartial(@NotNull Authentication.LoginCredentials credentials, boolean removeLock) throws IOException, GeneralSecurityException, SpotifyAuthenticationException {
+		if (cipherPair == null)
+			throw new IllegalStateException("Connection not established!");
 
         Authentication.ClientResponseEncrypted clientResponseEncrypted = Authentication.ClientResponseEncrypted.newBuilder()
                 .setLoginCredentials(credentials)
                 .setSystemInfo(Authentication.SystemInfo.newBuilder()
                         .setOs(Authentication.Os.OS_UNKNOWN)
                         .setCpuFamily(Authentication.CpuFamily.CPU_UNKNOWN)
-                        .setSystemInformationString(Version.systemInfoString())
-                        .setDeviceId(inner.deviceId)
-                        .build())
-                .setVersionString(Version.versionString())
-                .build();
+						.setSystemInformationString(Version.systemInfoString()).setDeviceId(inner.deviceId).build()).setVersionString(Version.versionString()).build();
 
-        sendUnchecked(Packet.Type.Login, clientResponseEncrypted.toByteArray());
+		sendUnchecked(Packet.Type.Login, clientResponseEncrypted.toByteArray());
 
-        Packet packet = cipherPair.receiveEncoded(conn.in);
-        if (packet.is(Packet.Type.APWelcome)) {
-            apWelcome = Authentication.APWelcome.parseFrom(packet.payload);
+		Packet packet = cipherPair.receiveEncoded(conn.in);
+		if (packet.is(Packet.Type.APWelcome)) {
+			apWelcome = Authentication.APWelcome.parseFrom(packet.payload);
 
-            receiver = new Receiver();
-            new Thread(receiver, "session-packet-receiver").start();
+			receiver = new Receiver();
+			new Thread(receiver, "session-packet-receiver").start();
 
-            byte[] bytes0x0f = new byte[20];
-            random().nextBytes(bytes0x0f);
-            sendUnchecked(Packet.Type.Unknown_0x0f, bytes0x0f);
+			byte[] bytes0x0f = new byte[20];
+			random().nextBytes(bytes0x0f);
+			sendUnchecked(Packet.Type.Unknown_0x0f, bytes0x0f);
 
-            ByteBuffer preferredLocale = ByteBuffer.allocate(18 + 5);
-            preferredLocale.put((byte) 0x0).put((byte) 0x0).put((byte) 0x10).put((byte) 0x0).put((byte) 0x02);
-            preferredLocale.put("preferred-locale".getBytes());
-            preferredLocale.put(inner.configuration.preferredLocale().getBytes());
-            sendUnchecked(Packet.Type.PreferredLocale, preferredLocale.array());
+			ByteBuffer preferredLocale = ByteBuffer.allocate(18 + 5);
+			preferredLocale.put((byte) 0x0).put((byte) 0x0).put((byte) 0x10).put((byte) 0x0).put((byte) 0x02);
+			preferredLocale.put("preferred-locale".getBytes());
+			preferredLocale.put(inner.configuration.preferredLocale().getBytes());
+			sendUnchecked(Packet.Type.PreferredLocale, preferredLocale.array());
 
-            if (removeLock) {
-                synchronized (authLock) {
-                    authLock.set(false);
-                    authLock.notifyAll();
-                }
-            }
+			if (removeLock) {
+				synchronized (authLock) {
+					authLock.set(false);
+					authLock.notifyAll();
+				}
+			}
 
-            if (conf().storeCredentials()) {
-                ByteString reusable = apWelcome.getReusableAuthCredentials();
-                Authentication.AuthenticationType reusableType = apWelcome.getReusableAuthCredentialsType();
+			if (conf().storeCredentials()) {
+				ByteString reusable = apWelcome.getReusableAuthCredentials();
+				Authentication.AuthenticationType reusableType = apWelcome.getReusableAuthCredentialsType();
 
-                JsonObject obj = new JsonObject();
-                obj.addProperty("username", apWelcome.getCanonicalUsername());
-                obj.addProperty("credentials", Utils.toBase64(reusable));
-                obj.addProperty("type", reusableType.name());
+				JsonObject obj = new JsonObject();
+				obj.addProperty("username", apWelcome.getCanonicalUsername());
+				obj.addProperty("credentials", Utils.toBase64(reusable));
+				obj.addProperty("type", reusableType.name());
 
-                File storeFile = conf().credentialsFile();
-                if (storeFile == null) throw new IllegalArgumentException();
-                try (FileOutputStream out = new FileOutputStream(storeFile)) {
-                    out.write(obj.toString().getBytes());
-                }
-            }
-        } else if (packet.is(Packet.Type.AuthFailure)) {
-            throw new SpotifyAuthenticationException(Keyexchange.APLoginFailed.parseFrom(packet.payload));
-        } else {
-            throw new IllegalStateException("Unknown CMD 0x" + Integer.toHexString(packet.cmd));
-        }
-    }
+				File storeFile = conf().credentialsFile();
+				if (storeFile == null)
+					throw new IllegalArgumentException();
+				try (FileOutputStream out = new FileOutputStream(storeFile)) {
+					out.write(obj.toString().getBytes());
+				}
+			}
+		} else if (packet.is(Packet.Type.AuthFailure)) {
+			throw new SpotifyAuthenticationException(Keyexchange.APLoginFailed.parseFrom(packet.payload));
+		} else {
+			throw new IllegalStateException("Unknown CMD 0x" + Integer.toHexString(packet.cmd));
+		}
+	}
 
-    @Override
-    public void close() throws IOException {
-        if (receiver != null) {
-            receiver.stop();
-            receiver = null;
-        }
+	@Override
+	public void close() throws IOException {
+		LOGGER.info(String.format("Closing session. {deviceId: %s} ", inner.deviceId));
 
-        if (player != null) {
-            player.close();
-            player = null;
-        }
+		scheduler.shutdownNow();
 
-        if (dealer != null) {
-            dealer.close();
-            dealer = null;
-        }
+		if (receiver != null) {
+			receiver.stop();
+			receiver = null;
+		}
 
-        if (audioKeyManager != null) {
-            audioKeyManager.close();
-            audioKeyManager = null;
-        }
+		if (player != null) {
+			player.close();
+			player = null;
+		}
 
-        if (channelManager != null) {
-            channelManager.close();
-            channelManager = null;
-        }
+		if (dealer != null) {
+			dealer.close();
+			dealer = null;
+		}
 
-        if (mercuryClient != null) {
-            mercuryClient.close();
-            mercuryClient = null;
-        }
+		if (audioKeyManager != null) {
+			audioKeyManager.close();
+			audioKeyManager = null;
+		}
 
-        executorService.shutdown();
-        conn.socket.close();
+		if (channelManager != null) {
+			channelManager.close();
+			channelManager = null;
+		}
+
+		if (mercuryClient != null) {
+			mercuryClient.close();
+			mercuryClient = null;
+		}
+
+		executorService.shutdown();
+
+		if (conn != null) {
+			conn.socket.close();
+			conn = null;
+		}
 
         synchronized (authLock) {
-            apWelcome = null;
-            cipherPair = null;
-            closed = true;
+		apWelcome = null;
+		cipherPair = null;
+		closed = true;
         }
 
-        synchronized (closeListeners) {
-            Iterator<CloseListener> i = closeListeners.iterator();
-            while (i.hasNext()) {
-                i.next().onClosed();
-                i.remove();
-            }
-        }
+		synchronized (closeListeners) {
+			Iterator<CloseListener> i = closeListeners.iterator();
+			while (i.hasNext()) {
+				i.next().onClosed();
+				i.remove();
+			}
+		}
 
-        LOGGER.info(String.format("Closed session. {deviceId: %s, ap: %s} ", inner.deviceId, conn.socket.getInetAddress()));
-    }
+		LOGGER.info(String.format("Closed session. {deviceId: %s} ", inner.deviceId));
+	}
 
-    private void sendUnchecked(Packet.Type cmd, byte[] payload) throws IOException {
-        cipherPair.sendEncoded(conn.out, cmd.val, payload);
-    }
+	private void sendUnchecked(Packet.Type cmd, byte[] payload) throws IOException {
+		cipherPair.sendEncoded(conn.out, cmd.val, payload);
+	}
 
-    private void waitAuthLock() {
+	private void waitAuthLock() {
         if (closed) throw new IllegalStateException("Session is closed!");
 
         synchronized (authLock) {
@@ -473,624 +459,626 @@ public final class Session implements Closeable, SubListener {
                 }
             }
 
-            sendUnchecked(cmd, payload);
-        }
+		sendUnchecked(cmd, payload);
+	}
     }
 
-    @NotNull
-    public MercuryClient mercury() {
-        waitAuthLock();
-        if (mercuryClient == null) throw new IllegalStateException("Session isn't authenticated!");
-        return mercuryClient;
-    }
-
-    @NotNull
-    public AudioKeyManager audioKey() {
-        waitAuthLock();
-        if (audioKeyManager == null) throw new IllegalStateException("Session isn't authenticated!");
-        return audioKeyManager;
-    }
-
-    @NotNull
-    public CacheManager cache() {
-        waitAuthLock();
-        if (cacheManager == null) throw new IllegalStateException("Session isn't authenticated!");
-        return cacheManager;
-    }
-
-    @NotNull
-    public CdnManager cdn() {
-        waitAuthLock();
-        if (cdnManager == null) throw new IllegalStateException("Session isn't authenticated!");
-        return cdnManager;
-    }
-
-    @NotNull
-    public ChannelManager channel() {
-        waitAuthLock();
-        if (channelManager == null) throw new IllegalStateException("Session isn't authenticated!");
-        return channelManager;
-    }
-
-    @NotNull
-    public TokenProvider tokens() {
-        waitAuthLock();
-        if (tokenProvider == null) throw new IllegalStateException("Session isn't authenticated!");
-        return tokenProvider;
-    }
-
-    @NotNull
-    public DealerClient dealer() {
-        waitAuthLock();
-        if (dealer == null) throw new IllegalStateException("Session isn't authenticated!");
-        return dealer;
-    }
-
-    @NotNull
-    public ApiClient api() {
-        waitAuthLock();
-        if (api == null) throw new IllegalStateException("Session isn't authenticated!");
-        return api;
-    }
-
-    @NotNull
-    public PlayableContentFeeder contentFeeder() {
-        waitAuthLock();
-        if (contentFeeder == null) throw new IllegalStateException("Session isn't authenticated!");
-        return contentFeeder;
-    }
-
-    @NotNull
-    public Player player() {
-        waitAuthLock();
-        if (player == null) throw new IllegalStateException("Session isn't authenticated!");
-        return player;
-    }
-
-    @NotNull
-    public SearchManager search() {
-        waitAuthLock();
-        if (search == null) throw new IllegalStateException("Session isn't authenticated!");
-        return search;
-    }
-
-    @NotNull
-    public String username() {
-        return apWelcome().getCanonicalUsername();
-    }
-
-    @NotNull
-    public Authentication.APWelcome apWelcome() {
-        waitAuthLock();
-        if (apWelcome == null) throw new IllegalStateException("Session isn't authenticated!");
-        return apWelcome;
-    }
-
-    public boolean valid() {
-        if (closed) return false;
-
-        waitAuthLock();
-        return apWelcome != null && conn != null && !conn.socket.isClosed();
-    }
-
-    public boolean reconnecting() {
-        return !closed && conn == null;
-    }
-
-    @NotNull
-    public String deviceId() {
-        return inner.deviceId;
-    }
-
-    @NotNull
-    public Connect.DeviceType deviceType() {
-        return inner.deviceType;
-    }
-
-    @NotNull
-    ExecutorService executor() {
-        return executorService;
-    }
-
-    @NotNull
-    public String deviceName() {
-        return inner.deviceName;
-    }
-
-    @NotNull
-    public Random random() {
-        return inner.random;
-    }
-
-    private void reconnect() {
-        synchronized (reconnectionListeners) {
-            reconnectionListeners.forEach(ReconnectionListener::onConnectionDropped);
-        }
-
-        try {
-            if (conn != null) {
-                conn.socket.close();
-                receiver.stop();
-            }
-
-            conn = ConnectionHolder.create(ApResolver.getRandomAccesspoint(), conf());
-            connect();
-            authenticatePartial(Authentication.LoginCredentials.newBuilder()
-                    .setUsername(apWelcome.getCanonicalUsername())
-                    .setTyp(apWelcome.getReusableAuthCredentialsType())
-                    .setAuthData(apWelcome.getReusableAuthCredentials())
-                    .build(), true);
-
-            LOGGER.info(String.format("Re-authenticated as %s!", apWelcome.getCanonicalUsername()));
-
-            synchronized (reconnectionListeners) {
-                reconnectionListeners.forEach(ReconnectionListener::onConnectionEstablished);
-            }
-        } catch (IOException | GeneralSecurityException | SpotifyAuthenticationException ex) {
-            conn = null;
-            LOGGER.error("Failed reconnecting, retrying in 10 seconds...", ex);
-            scheduler.schedule(this::reconnect, 10, TimeUnit.SECONDS);
-        }
-    }
-
-    @NotNull
-    public AbsConfiguration conf() {
-        return inner.configuration;
-    }
-
-    @Nullable
-    public String countryCode() {
-        return countryCode;
-    }
-
-    public void addCloseListener(@NotNull CloseListener listener) {
-        if (!closeListeners.contains(listener)) closeListeners.add(listener);
-    }
-
-    public void addReconnectionListener(@NotNull ReconnectionListener listener) {
-        if (!reconnectionListeners.contains(listener)) reconnectionListeners.add(listener);
-    }
-
-    private void parseProductInfo(@NotNull InputStream in) throws IOException, SAXException, ParserConfigurationException {
-        DocumentBuilder dBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-        Document doc = dBuilder.parse(in);
-
-        Node products = doc.getElementsByTagName("products").item(0);
-        if (products == null) return;
-
-        Node product = products.getChildNodes().item(0);
-        if (product == null) return;
-
-        NodeList properties = product.getChildNodes();
-        for (int i = 0; i < properties.getLength(); i++) {
-            Node node = properties.item(i);
-            userAttributes.put(node.getNodeName(), node.getTextContent());
-        }
-
-        LOGGER.trace("Parsed product info: " + userAttributes);
-    }
-
-    @Nullable
-    public String getUserAttribute(@NotNull String key) {
-        return userAttributes.get(key);
-    }
-
-    @Contract("_, !null -> !null")
-    public String getUserAttribute(@NotNull String key, @NotNull String fallback) {
-        return userAttributes.getOrDefault(key, fallback);
-    }
-
-    @Override
-    public void event(@NotNull MercuryClient.Response resp) {
-        if (resp.uri.equals("spotify:user:attributes:update")) {
-            UserAttributesUpdate attributesUpdate;
-            try {
-                attributesUpdate = UserAttributesUpdate.parseFrom(resp.payload.stream());
-            } catch (IOException ex) {
-                LOGGER.warn("Failed parsing user attributes update.", ex);
-                return;
-            }
-
-            for (ExplicitContentPubsub.KeyValuePair pair : attributesUpdate.getPairsList()) {
-                userAttributes.put(pair.getKey(), pair.getValue());
-                LOGGER.trace(String.format("Updated user attribute: %s -> %s", pair.getKey(), pair.getValue()));
-            }
-        }
-    }
-
-    public interface ReconnectionListener {
-        void onConnectionDropped();
-
-        void onConnectionEstablished();
-    }
-
-    public interface ProxyConfiguration {
-        boolean proxyEnabled();
-
-        @NotNull
-        Proxy.Type proxyType();
-
-        @NotNull
-        String proxyAddress();
-
-        int proxyPort();
-
-        boolean proxyAuth();
-
-        @NotNull
-        String proxyUsername();
-
-        @NotNull
-        String proxyPassword();
-    }
-
-    public interface CloseListener {
-        void onClosed();
-    }
-
-    static class Inner {
-        final Connect.DeviceType deviceType;
-        final String deviceName;
-        final SecureRandom random;
-        final String deviceId;
-        final AbsConfiguration configuration;
-
-        private Inner(Connect.DeviceType deviceType, String deviceName, AbsConfiguration configuration) {
-            this.deviceType = deviceType;
-            this.deviceName = deviceName;
-            this.configuration = configuration;
-            this.random = new SecureRandom();
-
-            String configuredDeviceId = configuration.deviceId();
-            this.deviceId = (configuredDeviceId == null || configuredDeviceId.isEmpty()) ?
-                    Utils.randomHexString(random, 40).toLowerCase() : configuredDeviceId;
-        }
-
-        @NotNull
-        static Inner from(@NotNull AbsConfiguration configuration) {
-            String deviceName = configuration.deviceName();
-            if (deviceName == null || deviceName.isEmpty())
-                throw new IllegalArgumentException("Device name required: " + deviceName);
-
-            Connect.DeviceType deviceType = configuration.deviceType();
-            if (deviceType == null)
-                throw new IllegalArgumentException("Device type required!");
-
-            return new Inner(deviceType, deviceName, configuration);
-        }
-
-        @NotNull Authentication.LoginCredentials decryptBlob(String username, byte[] encryptedBlob) throws GeneralSecurityException, IOException {
-            encryptedBlob = Base64.getDecoder().decode(encryptedBlob);
-
-            byte[] secret = MessageDigest.getInstance("SHA-1").digest(deviceId.getBytes());
-            byte[] baseKey = PBKDF2.HmacSHA1(secret, username.getBytes(), 0x100, 20);
-
-            byte[] key = ByteBuffer.allocate(24)
-                    .put(MessageDigest.getInstance("SHA-1").digest(baseKey))
-                    .putInt(20)
-                    .array();
-
-            Cipher aes = Cipher.getInstance("AES/ECB/NoPadding");
-            aes.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"));
-            byte[] decryptedBlob = aes.doFinal(encryptedBlob);
-
-            int l = decryptedBlob.length;
-            for (int i = 0; i < l - 0x10; i++)
-                decryptedBlob[l - i - 1] ^= decryptedBlob[l - i - 0x11];
-
-            ByteBuffer blob = ByteBuffer.wrap(decryptedBlob);
-            blob.get();
-            int len = readBlobInt(blob);
-            blob.get(new byte[len]);
-            blob.get();
-
-            int typeInt = readBlobInt(blob);
-            Authentication.AuthenticationType type = Authentication.AuthenticationType.forNumber(typeInt);
-            if (type == null)
-                throw new IOException(new IllegalArgumentException("Unknown AuthenticationType: " + typeInt));
-
-            blob.get();
-
-            len = readBlobInt(blob);
-            byte[] authData = new byte[len];
-            blob.get(authData);
-
-            return Authentication.LoginCredentials.newBuilder()
-                    .setUsername(username)
-                    .setTyp(type)
-                    .setAuthData(ByteString.copyFrom(authData))
-                    .build();
-        }
-    }
-
-    /**
-     * Builder for setting up a {@link Session} object.
-     */
-    public static class Builder {
-        private final Inner inner;
-        private final AuthConfiguration authConf;
-        private Authentication.LoginCredentials loginCredentials = null;
-
-        public Builder(@NotNull Connect.DeviceType deviceType, @NotNull String deviceName, @NotNull AbsConfiguration configuration) {
-            this.inner = new Inner(deviceType, deviceName, configuration);
-            this.authConf = configuration;
-        }
-
-        public Builder(@NotNull AbsConfiguration configuration) {
-            this.inner = Inner.from(configuration);
-            this.authConf = configuration;
-        }
-
-        /**
-         * Authenticate with your Facebook account, will prompt to open a link in the browser.
-         */
-        @NotNull
-        public Builder facebook() throws IOException {
-            try (FacebookAuthenticator authenticator = new FacebookAuthenticator()) {
-                loginCredentials = authenticator.lockUntilCredentials();
-                return this;
-            } catch (InterruptedException ex) {
-                throw new IOException(ex);
-            }
-        }
-
-        /**
-         * Authenticate with a saved credentials blob.
-         *
-         * @param username Your Spotify username
-         * @param blob     The Base64-decoded blob
-         */
-        @NotNull
-        public Builder blob(String username, byte[] blob) throws GeneralSecurityException, IOException {
-            loginCredentials = inner.decryptBlob(username, blob);
-            return this;
-        }
-
-        /**
-         * Authenticate with username and password. The credentials won't be saved.
-         *
-         * @param username Your Spotify username
-         * @param password Your Spotify password
-         */
-        @NotNull
-        public Builder userPass(@NotNull String username, @NotNull String password) {
-            loginCredentials = Authentication.LoginCredentials.newBuilder()
-                    .setUsername(username)
-                    .setTyp(Authentication.AuthenticationType.AUTHENTICATION_USER_PASS)
-                    .setAuthData(ByteString.copyFromUtf8(password))
-                    .build();
-            return this;
-        }
-
-        /**
-         * Creates a connected and fully authenticated {@link Session} object.
-         */
-        @NotNull
-        public Session create() throws IOException, GeneralSecurityException, SpotifyAuthenticationException, MercuryClient.MercuryException {
-            if (authConf.storeCredentials()) {
-                File storeFile = authConf.credentialsFile();
-                if (storeFile != null && storeFile.exists()) {
-                    JsonObject obj = JsonParser.parseReader(new FileReader(storeFile)).getAsJsonObject();
-                    loginCredentials = Authentication.LoginCredentials.newBuilder()
-                            .setTyp(Authentication.AuthenticationType.valueOf(obj.get("type").getAsString()))
-                            .setUsername(obj.get("username").getAsString())
-                            .setAuthData(Utils.fromBase64(obj.get("credentials").getAsString()))
-                            .build();
-                }
-            }
-
-            if (loginCredentials == null) {
-                String blob = authConf.authBlob();
-                String username = authConf.authUsername();
-                String password = authConf.authPassword();
-
-                switch (authConf.authStrategy()) {
-                    case FACEBOOK:
-                        facebook();
-                        break;
-                    case BLOB:
-                        if (username == null) throw new IllegalArgumentException("Missing authUsername!");
-                        if (blob == null) throw new IllegalArgumentException("Missing authBlob!");
-                        blob(username, Base64.getDecoder().decode(blob));
-                        break;
-                    case USER_PASS:
-                        if (username == null) throw new IllegalArgumentException("Missing authUsername!");
-                        if (password == null) throw new IllegalArgumentException("Missing authPassword!");
-                        userPass(username, password);
-                        break;
-                    case ZEROCONF:
-                        throw new IllegalStateException("Cannot handle ZEROCONF! Use ZeroconfServer.");
-                    default:
-                        throw new IllegalStateException("Unknown auth authStrategy: " + authConf.authStrategy());
-                }
-            }
-
-            Session session = Session.from(inner);
-            session.connect();
-            session.authenticate(loginCredentials);
-            return session;
-        }
-    }
-
-    public static class SpotifyAuthenticationException extends Exception {
-        private SpotifyAuthenticationException(Keyexchange.APLoginFailed loginFailed) {
-            super(loginFailed.getErrorCode().name());
-        }
-    }
-
-    private static class Accumulator extends DataOutputStream {
-        private byte[] bytes;
-
-        Accumulator() {
-            super(new ByteArrayOutputStream());
-        }
-
-        void dump() throws IOException {
-            bytes = ((ByteArrayOutputStream) this.out).toByteArray();
-            this.close();
-        }
-
-        @NotNull
-        byte[] array() {
-            return bytes;
-        }
-    }
-
-    private static class ConnectionHolder {
-        final Socket socket;
-        final DataInputStream in;
-        final DataOutputStream out;
-
-        private ConnectionHolder(@NotNull Socket socket) throws IOException {
-            this.socket = socket;
-            this.in = new DataInputStream(socket.getInputStream());
-            this.out = new DataOutputStream(socket.getOutputStream());
-        }
-
-        @NotNull
-        static ConnectionHolder create(@NotNull String addr, @NotNull ProxyConfiguration conf) throws IOException {
-            int colon = addr.indexOf(':');
-            String apAddr = addr.substring(0, colon);
-            int apPort = Integer.parseInt(addr.substring(colon + 1));
-            if (!conf.proxyEnabled() || conf.proxyType() == Proxy.Type.DIRECT)
-                return new ConnectionHolder(new Socket(apAddr, apPort));
-
-            switch (conf.proxyType()) {
-                case HTTP:
-                    Socket sock = new Socket(conf.proxyAddress(), conf.proxyPort());
-                    OutputStream out = sock.getOutputStream();
-                    DataInputStream in = new DataInputStream(sock.getInputStream());
-
-                    out.write(String.format("CONNECT %s:%d HTTP/1.0\n", apAddr, apPort).getBytes());
-                    if (conf.proxyAuth()) {
-                        out.write("Proxy-Authorization: Basic ".getBytes());
-                        out.write(Base64.getEncoder().encodeToString(String.format("%s:%s\n", conf.proxyUsername(), conf.proxyPassword()).getBytes()).getBytes());
-                    }
-
-                    out.write('\n');
-                    out.flush();
-
-                    String sl = Utils.readLine(in);
-                    if (!sl.contains("200")) throw new IOException("Failed connecting: " + sl);
-
-                    //noinspection StatementWithEmptyBody
-                    while (!Utils.readLine(in).isEmpty()) {
-                        // Read all headers
-                    }
-
-                    LOGGER.info("Successfully connected to the HTTP proxy.");
-                    return new ConnectionHolder(sock);
-                case SOCKS:
-                    if (conf.proxyAuth()) {
-                        java.net.Authenticator.setDefault(new java.net.Authenticator() {
-                            final String username = conf.proxyUsername();
-                            final String password = conf.proxyPassword();
-
-                            @Override
-                            protected PasswordAuthentication getPasswordAuthentication() {
-                                if (Objects.equals(getRequestingProtocol(), "SOCKS5") && Objects.equals(getRequestingPrompt(), "SOCKS authentication"))
-                                    return new PasswordAuthentication(username, password.toCharArray());
-
-                                return super.getPasswordAuthentication();
-                            }
-                        });
-                    }
-
-                    Proxy proxy = new Proxy(conf.proxyType(), new InetSocketAddress(conf.proxyAddress(), conf.proxyPort()));
-                    Socket proxySocket = new Socket(proxy);
-                    proxySocket.connect(new InetSocketAddress(apAddr, apPort));
-                    LOGGER.info("Successfully connected to the SOCKS proxy.");
-                    return new ConnectionHolder(proxySocket);
-                case DIRECT:
-                default:
-                    throw new UnsupportedOperationException();
-            }
-        }
-    }
-
-    private class Receiver implements Runnable {
-        private volatile boolean shouldStop = false;
-
-        private Receiver() {
-        }
-
-        void stop() {
-            shouldStop = true;
-        }
-
-        @Override
-        public void run() {
-            while (!shouldStop) {
-                Packet packet;
-                Packet.Type cmd;
-                try {
-                    packet = cipherPair.receiveEncoded(conn.in);
-                    cmd = Packet.Type.parse(packet.cmd);
-                    if (cmd == null) {
-                        LOGGER.info(String.format("Skipping unknown command {cmd: 0x%s, payload: %s}", Integer.toHexString(packet.cmd), Utils.bytesToHex(packet.payload)));
-                        continue;
-                    }
-                } catch (IOException | GeneralSecurityException ex) {
-                    if (!shouldStop) {
-                        LOGGER.fatal("Failed reading packet!", ex);
-                        reconnect();
-                    }
-
-                    return;
-                }
-
-                if (shouldStop) return;
-
-                switch (cmd) {
-                    case Ping:
-                        if (scheduledReconnect != null) scheduledReconnect.cancel(true);
-                        scheduledReconnect = scheduler.schedule(() -> {
-                            LOGGER.warn("Socket timed out. Reconnecting...");
-                            reconnect();
-                        }, 2 * 60 + 5, TimeUnit.SECONDS);
-
-                        TimeProvider.updateWithPing(packet.payload);
-
-                        try {
-                            send(Packet.Type.Pong, packet.payload);
-                        } catch (IOException ex) {
-                            LOGGER.fatal("Failed sending Pong!", ex);
-                        }
-                        break;
-                    case PongAck:
-                        // Silent
-                        break;
-                    case CountryCode:
-                        countryCode = new String(packet.payload);
-                        LOGGER.info("Received CountryCode: " + countryCode);
-                        break;
-                    case LicenseVersion:
-                        ByteBuffer licenseVersion = ByteBuffer.wrap(packet.payload);
-                        short id = licenseVersion.getShort();
-                        if (id != 0) {
-                            byte[] buffer = new byte[licenseVersion.get()];
-                            licenseVersion.get(buffer);
-                            LOGGER.info(String.format("Received LicenseVersion: %d, %s", id, new String(buffer)));
-                        } else {
-                            LOGGER.info(String.format("Received LicenseVersion: %d", id));
-                        }
-                        break;
-                    case Unknown_0x10:
-                        LOGGER.debug("Received 0x10: " + Utils.bytesToHex(packet.payload));
-                        break;
-                    case MercurySub:
-                    case MercuryUnsub:
-                    case MercuryEvent:
-                    case MercuryReq:
-                        mercury().dispatch(packet);
-                        break;
-                    case AesKey:
-                    case AesKeyError:
-                        audioKey().dispatch(packet);
-                        break;
-                    case ChannelError:
-                    case StreamChunkRes:
-                        channel().dispatch(packet);
+	@NotNull
+	public MercuryClient mercury() {
+		waitAuthLock();
+		if (mercuryClient == null)
+			throw new IllegalStateException("Session isn't authenticated!");
+		return mercuryClient;
+	}
+
+	@NotNull
+	public AudioKeyManager audioKey() {
+		waitAuthLock();
+		if (audioKeyManager == null)
+			throw new IllegalStateException("Session isn't authenticated!");
+		return audioKeyManager;
+	}
+
+	@NotNull
+	public CacheManager cache() {
+		waitAuthLock();
+		if (cacheManager == null)
+			throw new IllegalStateException("Session isn't authenticated!");
+		return cacheManager;
+	}
+
+	@NotNull
+	public CdnManager cdn() {
+		waitAuthLock();
+		if (cdnManager == null)
+			throw new IllegalStateException("Session isn't authenticated!");
+		return cdnManager;
+	}
+
+	@NotNull
+	public ChannelManager channel() {
+		waitAuthLock();
+		if (channelManager == null)
+			throw new IllegalStateException("Session isn't authenticated!");
+		return channelManager;
+	}
+
+	@NotNull
+	public TokenProvider tokens() {
+		waitAuthLock();
+		if (tokenProvider == null)
+			throw new IllegalStateException("Session isn't authenticated!");
+		return tokenProvider;
+	}
+
+	@NotNull
+	public DealerClient dealer() {
+		waitAuthLock();
+		if (dealer == null)
+			throw new IllegalStateException("Session isn't authenticated!");
+		return dealer;
+	}
+
+	@NotNull
+	public ApiClient api() {
+		waitAuthLock();
+		if (api == null)
+			throw new IllegalStateException("Session isn't authenticated!");
+		return api;
+	}
+
+	@NotNull
+	public PlayableContentFeeder contentFeeder() {
+		waitAuthLock();
+		if (contentFeeder == null)
+			throw new IllegalStateException("Session isn't authenticated!");
+		return contentFeeder;
+	}
+
+	@NotNull
+	public Player player() {
+		waitAuthLock();
+		if (player == null)
+			throw new IllegalStateException("Session isn't authenticated!");
+		return player;
+	}
+
+	@NotNull
+	public SearchManager search() {
+		waitAuthLock();
+		if (search == null)
+			throw new IllegalStateException("Session isn't authenticated!");
+		return search;
+	}
+
+	@NotNull
+	public String username() {
+		return apWelcome().getCanonicalUsername();
+	}
+
+	@NotNull
+	public Authentication.APWelcome apWelcome() {
+		waitAuthLock();
+		if (apWelcome == null)
+			throw new IllegalStateException("Session isn't authenticated!");
+		return apWelcome;
+	}
+
+	public boolean valid() {
+		if (closed)
+			return false;
+
+		waitAuthLock();
+		return apWelcome != null && conn != null && !conn.socket.isClosed();
+	}
+
+	public boolean reconnecting() {
+		return !closed && conn == null;
+	}
+
+	@NotNull
+	public String deviceId() {
+		return inner.deviceId;
+	}
+
+	@NotNull
+	public Connect.DeviceType deviceType() {
+		return inner.deviceType;
+	}
+
+	@NotNull ExecutorService executor() {
+		return executorService;
+	}
+
+	@NotNull
+	public String deviceName() {
+		return inner.deviceName;
+	}
+
+	@NotNull
+	public Random random() {
+		return inner.random;
+	}
+
+	private void reconnect() {
+		synchronized (reconnectionListeners) {
+			reconnectionListeners.forEach(ReconnectionListener::onConnectionDropped);
+		}
+
+		try {
+			if (conn != null) {
+				conn.socket.close();
+				receiver.stop();
+			}
+
+			conn = ConnectionHolder.create(ApResolver.getRandomAccesspoint(), conf());
+			connect();
+			authenticatePartial(Authentication.LoginCredentials.newBuilder().setUsername(apWelcome.getCanonicalUsername()).setTyp(apWelcome.getReusableAuthCredentialsType())
+					.setAuthData(apWelcome.getReusableAuthCredentials()).build(), true);
+
+			LOGGER.info(String.format("Re-authenticated as %s!", apWelcome.getCanonicalUsername()));
+
+			synchronized (reconnectionListeners) {
+				reconnectionListeners.forEach(ReconnectionListener::onConnectionEstablished);
+			}
+		} catch (IOException | GeneralSecurityException | SpotifyAuthenticationException ex) {
+			conn = null;
+			LOGGER.error("Failed reconnecting, retrying in 10 seconds...", ex);
+			scheduler.schedule(this::reconnect, 10, TimeUnit.SECONDS);
+		}
+	}
+
+	@NotNull
+	public AbsConfiguration conf() {
+		return inner.configuration;
+	}
+
+	@Nullable
+	public String countryCode() {
+		return countryCode;
+	}
+
+	public void addCloseListener(@NotNull CloseListener listener) {
+		if (!closeListeners.contains(listener))
+			closeListeners.add(listener);
+	}
+
+	public void addReconnectionListener(@NotNull ReconnectionListener listener) {
+		if (!reconnectionListeners.contains(listener))
+			reconnectionListeners.add(listener);
+	}
+
+	private void parseProductInfo(@NotNull InputStream in) throws IOException, SAXException, ParserConfigurationException {
+		DocumentBuilder dBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+		Document doc = dBuilder.parse(in);
+
+		Node products = doc.getElementsByTagName("products").item(0);
+		if (products == null) return;
+
+		Node product = products.getChildNodes().item(0);
+		if (product == null) return;
+
+		NodeList properties = product.getChildNodes();
+		for (int i = 0; i < properties.getLength(); i++) {
+			Node node = properties.item(i);
+			userAttributes.put(node.getNodeName(), node.getTextContent());
+		}
+
+		LOGGER.trace("Parsed product info: " + userAttributes);
+	}
+
+	@Nullable
+	public String getUserAttribute(@NotNull String key) {
+		return userAttributes.get(key);
+	}
+
+	@Contract("_, !null -> !null")
+	public String getUserAttribute(@NotNull String key, @NotNull String fallback) {
+		return userAttributes.getOrDefault(key, fallback);
+	}
+
+	@Override
+	public void event(@NotNull MercuryClient.Response resp) {
+		if (resp.uri.equals("spotify:user:attributes:update")) {
+			UserAttributesUpdate attributesUpdate;
+			try {
+				attributesUpdate = UserAttributesUpdate.parseFrom(resp.payload.stream());
+			} catch (IOException ex) {
+				LOGGER.warn("Failed parsing user attributes update.", ex);
+				return;
+			}
+
+			for (ExplicitContentPubsub.KeyValuePair pair : attributesUpdate.getPairsList()) {
+				userAttributes.put(pair.getKey(), pair.getValue());
+				LOGGER.trace(String.format("Updated user attribute: %s -> %s", pair.getKey(), pair.getValue()));
+			}
+		}
+	}
+
+	public interface ReconnectionListener {
+		void onConnectionDropped();
+
+		void onConnectionEstablished();
+	}
+
+	public interface ProxyConfiguration {
+		boolean proxyEnabled();
+
+		@NotNull Proxy.Type proxyType();
+
+		@NotNull String proxyAddress();
+
+		int proxyPort();
+
+		boolean proxyAuth();
+
+		@NotNull String proxyUsername();
+
+		@NotNull String proxyPassword();
+	}
+
+	public interface CloseListener {
+		void onClosed();
+	}
+
+	static class Inner {
+		final Connect.DeviceType deviceType;
+		final String deviceName;
+		final SecureRandom random;
+		final String deviceId;
+		final AbsConfiguration configuration;
+
+		private Inner(Connect.DeviceType deviceType, String deviceName, AbsConfiguration configuration) {
+			this.deviceType = deviceType;
+			this.deviceName = deviceName;
+			this.configuration = configuration;
+			this.random = new SecureRandom();
+
+			String configuredDeviceId = configuration.deviceId();
+			this.deviceId = (configuredDeviceId == null || configuredDeviceId.isEmpty()) ? Utils.randomHexString(random, 40).toLowerCase() : configuredDeviceId;
+		}
+
+		@NotNull
+		static Inner from(@NotNull AbsConfiguration configuration) {
+			String deviceName = configuration.deviceName();
+			if (deviceName == null || deviceName.isEmpty())
+				throw new IllegalArgumentException("Device name required: " + deviceName);
+
+			Connect.DeviceType deviceType = configuration.deviceType();
+			if (deviceType == null)
+				throw new IllegalArgumentException("Device type required!");
+
+			return new Inner(deviceType, deviceName, configuration);
+		}
+
+		@NotNull Authentication.LoginCredentials decryptBlob(String username, byte[] encryptedBlob) throws GeneralSecurityException, IOException {
+			encryptedBlob = Base64.getDecoder().decode(encryptedBlob);
+
+			byte[] secret = MessageDigest.getInstance("SHA-1").digest(deviceId.getBytes());
+			byte[] baseKey = PBKDF2.HmacSHA1(secret, username.getBytes(), 0x100, 20);
+
+			byte[] key = ByteBuffer.allocate(24).put(MessageDigest.getInstance("SHA-1").digest(baseKey)).putInt(20).array();
+
+			Cipher aes = Cipher.getInstance("AES/ECB/NoPadding");
+			aes.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"));
+			byte[] decryptedBlob = aes.doFinal(encryptedBlob);
+
+			int l = decryptedBlob.length;
+			for (int i = 0; i < l - 0x10; i++)
+				decryptedBlob[l - i - 1] ^= decryptedBlob[l - i - 0x11];
+
+			ByteBuffer blob = ByteBuffer.wrap(decryptedBlob);
+			blob.get();
+			int len = readBlobInt(blob);
+			blob.get(new byte[len]);
+			blob.get();
+
+			int typeInt = readBlobInt(blob);
+			Authentication.AuthenticationType type = Authentication.AuthenticationType.forNumber(typeInt);
+			if (type == null)
+				throw new IOException(new IllegalArgumentException("Unknown AuthenticationType: " + typeInt));
+
+			blob.get();
+
+			len = readBlobInt(blob);
+			byte[] authData = new byte[len];
+			blob.get(authData);
+
+			return Authentication.LoginCredentials.newBuilder().setUsername(username).setTyp(type).setAuthData(ByteString.copyFrom(authData)).build();
+		}
+	}
+
+	/**
+	 * Builder for setting up a {@link Session} object.
+	 */
+	public static class Builder {
+		private final Inner inner;
+		private final AuthConfiguration authConf;
+		private Authentication.LoginCredentials loginCredentials = null;
+
+		public Builder(@NotNull Connect.DeviceType deviceType, @NotNull String deviceName, @NotNull AbsConfiguration configuration) {
+			this.inner = new Inner(deviceType, deviceName, configuration);
+			this.authConf = configuration;
+		}
+
+		public Builder(@NotNull AbsConfiguration configuration) {
+			this.inner = Inner.from(configuration);
+			this.authConf = configuration;
+		}
+
+		/**
+		 * Authenticate with your Facebook account, will prompt to open a link in the browser.
+		 */
+		@NotNull
+		public Builder facebook() throws IOException {
+			try (FacebookAuthenticator authenticator = new FacebookAuthenticator()) {
+				loginCredentials = authenticator.lockUntilCredentials();
+				return this;
+			} catch (InterruptedException ex) {
+				throw new IOException(ex);
+			}
+		}
+
+		/**
+		 * Authenticate with a saved credentials blob.
+		 *
+		 * @param username Your Spotify username
+		 * @param blob     The Base64-decoded blob
+		 */
+		@NotNull
+		public Builder blob(String username, byte[] blob) throws GeneralSecurityException, IOException {
+			loginCredentials = inner.decryptBlob(username, blob);
+			return this;
+		}
+
+		/**
+		 * Authenticate with username and password. The credentials won't be saved.
+		 *
+		 * @param username Your Spotify username
+		 * @param password Your Spotify password
+		 */
+		@NotNull
+		public Builder userPass(@NotNull String username, @NotNull String password) {
+			loginCredentials = Authentication.LoginCredentials.newBuilder().setUsername(username).setTyp(Authentication.AuthenticationType.AUTHENTICATION_USER_PASS)
+					.setAuthData(ByteString.copyFromUtf8(password)).build();
+			return this;
+		}
+
+		/**
+		 * Creates a connected and fully authenticated {@link Session} object.
+		 */
+		@NotNull
+		public Session create() throws IOException, GeneralSecurityException, SpotifyAuthenticationException, MercuryClient.MercuryException {
+			if (authConf.storeCredentials()) {
+				File storeFile = authConf.credentialsFile();
+				if (storeFile != null && storeFile.exists()) {
+					JsonObject obj = JsonParser.parseReader(new FileReader(storeFile)).getAsJsonObject();
+					loginCredentials = Authentication.LoginCredentials.newBuilder().setTyp(Authentication.AuthenticationType.valueOf(obj.get("type").getAsString()))
+							.setUsername(obj.get("username").getAsString()).setAuthData(Utils.fromBase64(obj.get("credentials").getAsString())).build();
+				}
+			}
+
+			if (loginCredentials == null) {
+				String blob = authConf.authBlob();
+				String username = authConf.authUsername();
+				String password = authConf.authPassword();
+
+				switch (authConf.authStrategy()) {
+					case FACEBOOK:
+						facebook();
+						break;
+					case BLOB:
+						if (username == null)
+							throw new IllegalArgumentException("Missing authUsername!");
+						if (blob == null)
+							throw new IllegalArgumentException("Missing authBlob!");
+						blob(username, Base64.getDecoder().decode(blob));
+						break;
+					case USER_PASS:
+						if (username == null)
+							throw new IllegalArgumentException("Missing authUsername!");
+						if (password == null)
+							throw new IllegalArgumentException("Missing authPassword!");
+						userPass(username, password);
+						break;
+					case ZEROCONF:
+						throw new IllegalStateException("Cannot handle ZEROCONF! Use ZeroconfServer.");
+					default:
+						throw new IllegalStateException("Unknown auth authStrategy: " + authConf.authStrategy());
+				}
+			}
+
+			Session session = Session.from(inner);
+			session.connect();
+			session.authenticate(loginCredentials);
+			return session;
+		}
+	}
+
+	public static class SpotifyAuthenticationException extends Exception {
+		private SpotifyAuthenticationException(Keyexchange.APLoginFailed loginFailed) {
+			super(loginFailed.getErrorCode().name());
+		}
+	}
+
+	private static class Accumulator extends DataOutputStream {
+		private byte[] bytes;
+
+		Accumulator() {
+			super(new ByteArrayOutputStream());
+		}
+
+		void dump() throws IOException {
+			bytes = ((ByteArrayOutputStream) this.out).toByteArray();
+			this.close();
+		}
+
+		@NotNull byte[] array() {
+			return bytes;
+		}
+	}
+
+	private static class ConnectionHolder {
+		final Socket socket;
+		final DataInputStream in;
+		final DataOutputStream out;
+
+		private ConnectionHolder(@NotNull Socket socket) throws IOException {
+			this.socket = socket;
+			this.in = new DataInputStream(socket.getInputStream());
+			this.out = new DataOutputStream(socket.getOutputStream());
+		}
+
+		@NotNull
+		static ConnectionHolder create(@NotNull String addr, @NotNull ProxyConfiguration conf) throws IOException {
+			int colon = addr.indexOf(':');
+			String apAddr = addr.substring(0, colon);
+			int apPort = Integer.parseInt(addr.substring(colon + 1));
+			if (!conf.proxyEnabled() || conf.proxyType() == Proxy.Type.DIRECT)
+				return new ConnectionHolder(new Socket(apAddr, apPort));
+
+			switch (conf.proxyType()) {
+				case HTTP:
+					Socket sock = new Socket(conf.proxyAddress(), conf.proxyPort());
+					OutputStream out = sock.getOutputStream();
+					DataInputStream in = new DataInputStream(sock.getInputStream());
+
+					out.write(String.format("CONNECT %s:%d HTTP/1.0\n", apAddr, apPort).getBytes());
+					if (conf.proxyAuth()) {
+						out.write("Proxy-Authorization: Basic ".getBytes());
+						out.write(Base64.getEncoder().encodeToString(String.format("%s:%s\n", conf.proxyUsername(), conf.proxyPassword()).getBytes()).getBytes());
+					}
+
+					out.write('\n');
+					out.flush();
+
+					String sl = Utils.readLine(in);
+					if (!sl.contains("200"))
+						throw new IOException("Failed connecting: " + sl);
+
+					//noinspection StatementWithEmptyBody
+					while (!Utils.readLine(in).isEmpty()) {
+						// Read all headers
+					}
+
+					LOGGER.info("Successfully connected to the HTTP proxy.");
+					return new ConnectionHolder(sock);
+				case SOCKS:
+					if (conf.proxyAuth()) {
+						java.net.Authenticator.setDefault(new java.net.Authenticator() {
+							final String username = conf.proxyUsername();
+							final String password = conf.proxyPassword();
+
+							@Override
+							protected PasswordAuthentication getPasswordAuthentication() {
+								if (Objects.equals(getRequestingProtocol(), "SOCKS5") && Objects.equals(getRequestingPrompt(), "SOCKS authentication"))
+									return new PasswordAuthentication(username, password.toCharArray());
+
+								return super.getPasswordAuthentication();
+							}
+						});
+					}
+
+					Proxy proxy = new Proxy(conf.proxyType(), new InetSocketAddress(conf.proxyAddress(), conf.proxyPort()));
+					Socket proxySocket = new Socket(proxy);
+					proxySocket.connect(new InetSocketAddress(apAddr, apPort));
+					LOGGER.info("Successfully connected to the SOCKS proxy.");
+					return new ConnectionHolder(proxySocket);
+				case DIRECT:
+				default:
+					throw new UnsupportedOperationException();
+			}
+		}
+	}
+
+	private class Receiver implements Runnable {
+		private volatile boolean shouldStop = false;
+		private Thread thread;
+
+		private Receiver() {
+		}
+
+		void stop() {
+			shouldStop = true;
+			thread.interrupt();
+		}
+
+		@Override
+		public void run() {
+			LOGGER.trace("Session.Receiver started");
+			this.thread = Thread.currentThread();
+			while (!shouldStop) {
+				Packet packet;
+				Packet.Type cmd;
+				try {
+					packet = cipherPair.receiveEncoded(conn.in);
+					cmd = Packet.Type.parse(packet.cmd);
+					if (cmd == null) {
+						LOGGER.info(String.format("Skipping unknown command {cmd: 0x%s, payload: %s}", Integer.toHexString(packet.cmd), Utils.bytesToHex(packet.payload)));
+						continue;
+					}
+				} catch (IOException | GeneralSecurityException ex) {
+					if (!shouldStop) {
+						LOGGER.fatal("Failed reading packet!", ex);
+						reconnect();
+					}
+
+					break;
+				}
+
+				if (shouldStop) break;
+
+				switch (cmd) {
+					case Ping:
+						if (scheduledReconnect != null)
+							scheduledReconnect.cancel(true);
+						scheduledReconnect = scheduler.schedule(() -> {
+							LOGGER.warn("Socket timed out. Reconnecting...");
+							reconnect();
+						}, 2 * 60 + 5, TimeUnit.SECONDS);
+
+						TimeProvider.updateWithPing(packet.payload);
+
+						try {
+							send(Packet.Type.Pong, packet.payload);
+						} catch (IOException ex) {
+							LOGGER.fatal("Failed sending Pong!", ex);
+						}
+						break;
+					case PongAck:
+						// Silent
+						break;
+					case CountryCode:
+						countryCode = new String(packet.payload);
+						LOGGER.info("Received CountryCode: " + countryCode);
+						break;
+					case LicenseVersion:
+						ByteBuffer licenseVersion = ByteBuffer.wrap(packet.payload);
+						short id = licenseVersion.getShort();
+						if (id != 0) {
+							byte[] buffer = new byte[licenseVersion.get()];
+							licenseVersion.get(buffer);
+							LOGGER.info(String.format("Received LicenseVersion: %d, %s", id, new String(buffer)));
+						} else {
+							LOGGER.info(String.format("Received LicenseVersion: %d", id));
+						}
+						break;
+					case Unknown_0x10:
+						LOGGER.debug("Received 0x10: " + Utils.bytesToHex(packet.payload));
+						break;
+					case MercurySub:
+					case MercuryUnsub:
+					case MercuryEvent:
+					case MercuryReq:
+						mercury().dispatch(packet);
+						break;
+					case AesKey:
+					case AesKeyError:
+						audioKey().dispatch(packet);
+						break;
+					case ChannelError:
+					case StreamChunkRes:
+						channel().dispatch(packet);
                         break;
                     case ProductInfo:
                         try {
@@ -1098,12 +1086,14 @@ public final class Session implements Closeable, SubListener {
                         } catch (IOException | ParserConfigurationException | SAXException ex) {
                             LOGGER.warn("Failed parsing prodcut info!", ex);
                         }
-                        break;
-                    default:
-                        LOGGER.info("Skipping " + cmd.name());
-                        break;
-                }
-            }
-        }
-    }
+						break;
+					default:
+						LOGGER.info("Skipping " + cmd.name());
+						break;
+				}
+			}
+
+			LOGGER.trace("Session.Receiver stopped");
+		}
+	}
 }

--- a/core/src/main/java/xyz/gianlu/librespot/core/Session.java
+++ b/core/src/main/java/xyz/gianlu/librespot/core/Session.java
@@ -58,26 +58,30 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public final class Session implements Closeable, SubListener {
     private static final Logger LOGGER = Logger.getLogger(Session.class);
-    private static final byte[] serverKey = new byte[]{(byte) 0xac, (byte) 0xe0, (byte) 0x46, (byte) 0x0b, (byte) 0xff, (byte) 0xc2, (byte) 0x30, (byte) 0xaf, (byte) 0xf4, (byte) 0x6b,
-            (byte) 0xfe, (byte) 0xc3, (byte) 0xbf, (byte) 0xbf, (byte) 0x86, (byte) 0x3d, (byte) 0xa1, (byte) 0x91, (byte) 0xc6, (byte) 0xcc, (byte) 0x33, (byte) 0x6c, (byte) 0x93,
-            (byte) 0xa1, (byte) 0x4f, (byte) 0xb3, (byte) 0xb0, (byte) 0x16, (byte) 0x12, (byte) 0xac, (byte) 0xac, (byte) 0x6a, (byte) 0xf1, (byte) 0x80, (byte) 0xe7, (byte) 0xf6,
-            (byte) 0x14, (byte) 0xd9, (byte) 0x42, (byte) 0x9d, (byte) 0xbe, (byte) 0x2e, (byte) 0x34, (byte) 0x66, (byte) 0x43, (byte) 0xe3, (byte) 0x62, (byte) 0xd2, (byte) 0x32,
-            (byte) 0x7a, (byte) 0x1a, (byte) 0x0d, (byte) 0x92, (byte) 0x3b, (byte) 0xae, (byte) 0xdd, (byte) 0x14, (byte) 0x02, (byte) 0xb1, (byte) 0x81, (byte) 0x55, (byte) 0x05,
-            (byte) 0x61, (byte) 0x04, (byte) 0xd5, (byte) 0x2c, (byte) 0x96, (byte) 0xa4, (byte) 0x4c, (byte) 0x1e, (byte) 0xcc, (byte) 0x02, (byte) 0x4a, (byte) 0xd4, (byte) 0xb2,
-            (byte) 0x0c, (byte) 0x00, (byte) 0x1f, (byte) 0x17, (byte) 0xed, (byte) 0xc2, (byte) 0x2f, (byte) 0xc4, (byte) 0x35, (byte) 0x21, (byte) 0xc8, (byte) 0xf0, (byte) 0xcb,
-            (byte) 0xae, (byte) 0xd2, (byte) 0xad, (byte) 0xd7, (byte) 0x2b, (byte) 0x0f, (byte) 0x9d, (byte) 0xb3, (byte) 0xc5, (byte) 0x32, (byte) 0x1a, (byte) 0x2a, (byte) 0xfe,
-            (byte) 0x59, (byte) 0xf3, (byte) 0x5a, (byte) 0x0d, (byte) 0xac, (byte) 0x68, (byte) 0xf1, (byte) 0xfa, (byte) 0x62, (byte) 0x1e, (byte) 0xfb, (byte) 0x2c, (byte) 0x8d,
-            (byte) 0x0c, (byte) 0xb7, (byte) 0x39, (byte) 0x2d, (byte) 0x92, (byte) 0x47, (byte) 0xe3, (byte) 0xd7, (byte) 0x35, (byte) 0x1a, (byte) 0x6d, (byte) 0xbd, (byte) 0x24,
-            (byte) 0xc2, (byte) 0xae, (byte) 0x25, (byte) 0x5b, (byte) 0x88, (byte) 0xff, (byte) 0xab, (byte) 0x73, (byte) 0x29, (byte) 0x8a, (byte) 0x0b, (byte) 0xcc, (byte) 0xcd,
-            (byte) 0x0c, (byte) 0x58, (byte) 0x67, (byte) 0x31, (byte) 0x89, (byte) 0xe8, (byte) 0xbd, (byte) 0x34, (byte) 0x80, (byte) 0x78, (byte) 0x4a, (byte) 0x5f, (byte) 0xc9,
-            (byte) 0x6b, (byte) 0x89, (byte) 0x9d, (byte) 0x95, (byte) 0x6b, (byte) 0xfc, (byte) 0x86, (byte) 0xd7, (byte) 0x4f, (byte) 0x33, (byte) 0xa6, (byte) 0x78, (byte) 0x17,
-            (byte) 0x96, (byte) 0xc9, (byte) 0xc3, (byte) 0x2d, (byte) 0x0d, (byte) 0x32, (byte) 0xa5, (byte) 0xab, (byte) 0xcd, (byte) 0x05, (byte) 0x27, (byte) 0xe2, (byte) 0xf7,
-            (byte) 0x10, (byte) 0xa3, (byte) 0x96, (byte) 0x13, (byte) 0xc4, (byte) 0x2f, (byte) 0x99, (byte) 0xc0, (byte) 0x27, (byte) 0xbf, (byte) 0xed, (byte) 0x04, (byte) 0x9c,
-            (byte) 0x3c, (byte) 0x27, (byte) 0x58, (byte) 0x04, (byte) 0xb6, (byte) 0xb2, (byte) 0x19, (byte) 0xf9, (byte) 0xc1, (byte) 0x2f, (byte) 0x02, (byte) 0xe9, (byte) 0x48,
-            (byte) 0x63, (byte) 0xec, (byte) 0xa1, (byte) 0xb6, (byte) 0x42, (byte) 0xa0, (byte) 0x9d, (byte) 0x48, (byte) 0x25, (byte) 0xf8, (byte) 0xb3, (byte) 0x9d, (byte) 0xd0,
-            (byte) 0xe8, (byte) 0x6a, (byte) 0xf9, (byte) 0x48, (byte) 0x4d, (byte) 0xa1, (byte) 0xc2, (byte) 0xba, (byte) 0x86, (byte) 0x30, (byte) 0x42, (byte) 0xea, (byte) 0x9d,
-            (byte) 0xb3, (byte) 0x08, (byte) 0x6c, (byte) 0x19, (byte) 0x0e, (byte) 0x48, (byte) 0xb3, (byte) 0x9d, (byte) 0x66, (byte) 0xeb, (byte) 0x00, (byte) 0x06, (byte) 0xa2,
-            (byte) 0x5a, (byte) 0xee, (byte) 0xa1, (byte) 0x1b, (byte) 0x13, (byte) 0x87, (byte) 0x3c, (byte) 0xd7, (byte) 0x19, (byte) 0xe6, (byte) 0x55, (byte) 0xbd};
+    private static final byte[] serverKey = new byte[]{
+            (byte) 0xac, (byte) 0xe0, (byte) 0x46, (byte) 0x0b, (byte) 0xff, (byte) 0xc2, (byte) 0x30, (byte) 0xaf, (byte) 0xf4, (byte) 0x6b, (byte) 0xfe, (byte) 0xc3,
+            (byte) 0xbf, (byte) 0xbf, (byte) 0x86, (byte) 0x3d, (byte) 0xa1, (byte) 0x91, (byte) 0xc6, (byte) 0xcc, (byte) 0x33, (byte) 0x6c, (byte) 0x93, (byte) 0xa1,
+            (byte) 0x4f, (byte) 0xb3, (byte) 0xb0, (byte) 0x16, (byte) 0x12, (byte) 0xac, (byte) 0xac, (byte) 0x6a, (byte) 0xf1, (byte) 0x80, (byte) 0xe7, (byte) 0xf6,
+            (byte) 0x14, (byte) 0xd9, (byte) 0x42, (byte) 0x9d, (byte) 0xbe, (byte) 0x2e, (byte) 0x34, (byte) 0x66, (byte) 0x43, (byte) 0xe3, (byte) 0x62, (byte) 0xd2,
+            (byte) 0x32, (byte) 0x7a, (byte) 0x1a, (byte) 0x0d, (byte) 0x92, (byte) 0x3b, (byte) 0xae, (byte) 0xdd, (byte) 0x14, (byte) 0x02, (byte) 0xb1, (byte) 0x81,
+            (byte) 0x55, (byte) 0x05, (byte) 0x61, (byte) 0x04, (byte) 0xd5, (byte) 0x2c, (byte) 0x96, (byte) 0xa4, (byte) 0x4c, (byte) 0x1e, (byte) 0xcc, (byte) 0x02,
+            (byte) 0x4a, (byte) 0xd4, (byte) 0xb2, (byte) 0x0c, (byte) 0x00, (byte) 0x1f, (byte) 0x17, (byte) 0xed, (byte) 0xc2, (byte) 0x2f, (byte) 0xc4, (byte) 0x35,
+            (byte) 0x21, (byte) 0xc8, (byte) 0xf0, (byte) 0xcb, (byte) 0xae, (byte) 0xd2, (byte) 0xad, (byte) 0xd7, (byte) 0x2b, (byte) 0x0f, (byte) 0x9d, (byte) 0xb3,
+            (byte) 0xc5, (byte) 0x32, (byte) 0x1a, (byte) 0x2a, (byte) 0xfe, (byte) 0x59, (byte) 0xf3, (byte) 0x5a, (byte) 0x0d, (byte) 0xac, (byte) 0x68, (byte) 0xf1,
+            (byte) 0xfa, (byte) 0x62, (byte) 0x1e, (byte) 0xfb, (byte) 0x2c, (byte) 0x8d, (byte) 0x0c, (byte) 0xb7, (byte) 0x39, (byte) 0x2d, (byte) 0x92, (byte) 0x47,
+            (byte) 0xe3, (byte) 0xd7, (byte) 0x35, (byte) 0x1a, (byte) 0x6d, (byte) 0xbd, (byte) 0x24, (byte) 0xc2, (byte) 0xae, (byte) 0x25, (byte) 0x5b, (byte) 0x88,
+            (byte) 0xff, (byte) 0xab, (byte) 0x73, (byte) 0x29, (byte) 0x8a, (byte) 0x0b, (byte) 0xcc, (byte) 0xcd, (byte) 0x0c, (byte) 0x58, (byte) 0x67, (byte) 0x31,
+            (byte) 0x89, (byte) 0xe8, (byte) 0xbd, (byte) 0x34, (byte) 0x80, (byte) 0x78, (byte) 0x4a, (byte) 0x5f, (byte) 0xc9, (byte) 0x6b, (byte) 0x89, (byte) 0x9d,
+            (byte) 0x95, (byte) 0x6b, (byte) 0xfc, (byte) 0x86, (byte) 0xd7, (byte) 0x4f, (byte) 0x33, (byte) 0xa6, (byte) 0x78, (byte) 0x17, (byte) 0x96, (byte) 0xc9,
+            (byte) 0xc3, (byte) 0x2d, (byte) 0x0d, (byte) 0x32, (byte) 0xa5, (byte) 0xab, (byte) 0xcd, (byte) 0x05, (byte) 0x27, (byte) 0xe2, (byte) 0xf7, (byte) 0x10,
+            (byte) 0xa3, (byte) 0x96, (byte) 0x13, (byte) 0xc4, (byte) 0x2f, (byte) 0x99, (byte) 0xc0, (byte) 0x27, (byte) 0xbf, (byte) 0xed, (byte) 0x04, (byte) 0x9c,
+            (byte) 0x3c, (byte) 0x27, (byte) 0x58, (byte) 0x04, (byte) 0xb6, (byte) 0xb2, (byte) 0x19, (byte) 0xf9, (byte) 0xc1, (byte) 0x2f, (byte) 0x02, (byte) 0xe9,
+            (byte) 0x48, (byte) 0x63, (byte) 0xec, (byte) 0xa1, (byte) 0xb6, (byte) 0x42, (byte) 0xa0, (byte) 0x9d, (byte) 0x48, (byte) 0x25, (byte) 0xf8, (byte) 0xb3,
+            (byte) 0x9d, (byte) 0xd0, (byte) 0xe8, (byte) 0x6a, (byte) 0xf9, (byte) 0x48, (byte) 0x4d, (byte) 0xa1, (byte) 0xc2, (byte) 0xba, (byte) 0x86, (byte) 0x30,
+            (byte) 0x42, (byte) 0xea, (byte) 0x9d, (byte) 0xb3, (byte) 0x08, (byte) 0x6c, (byte) 0x19, (byte) 0x0e, (byte) 0x48, (byte) 0xb3, (byte) 0x9d, (byte) 0x66,
+            (byte) 0xeb, (byte) 0x00, (byte) 0x06, (byte) 0xa2, (byte) 0x5a, (byte) 0xee, (byte) 0xa1, (byte) 0x1b, (byte) 0x13, (byte) 0x87, (byte) 0x3c, (byte) 0xd7,
+            (byte) 0x19, (byte) 0xe6, (byte) 0x55, (byte) 0xbd
+    };
     private final DiffieHellman keys;
     private final Inner inner;
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(new NameThreadFactory(r -> "session-scheduler-" + r.hashCode()));
@@ -130,7 +134,9 @@ public final class Session implements Closeable, SubListener {
                     @Override
                     public Request authenticate(Route route, @NotNull Response response) {
                         String credential = Credentials.basic(username, password);
-                        return response.request().newBuilder().header("Proxy-Authorization", credential).build();
+                        return response.request().newBuilder()
+                                .header("Proxy-Authorization", credential)
+                                .build();
                     }
                 });
             }
@@ -141,8 +147,7 @@ public final class Session implements Closeable, SubListener {
 
     private static int readBlobInt(ByteBuffer buffer) {
         int lo = buffer.get();
-        if ((lo & 0x80) == 0)
-            return lo;
+        if ((lo & 0x80) == 0) return lo;
         int hi = buffer.get();
         return lo & 0x7f | hi << 7;
     }
@@ -167,10 +172,18 @@ public final class Session implements Closeable, SubListener {
         byte[] nonce = new byte[0x10];
         inner.random.nextBytes(nonce);
 
-        Keyexchange.ClientHello clientHello = Keyexchange.ClientHello.newBuilder().setBuildInfo(Version.standardBuildInfo())
-                .addCryptosuitesSupported(Keyexchange.Cryptosuite.CRYPTO_SUITE_SHANNON).setLoginCryptoHello(Keyexchange.LoginCryptoHelloUnion.newBuilder()
-                        .setDiffieHellman(Keyexchange.LoginCryptoDiffieHellmanHello.newBuilder().setGc(ByteString.copyFrom(keys.publicKeyArray())).setServerKeysKnown(1).build()).build())
-                .setClientNonce(ByteString.copyFrom(nonce)).setPadding(ByteString.copyFrom(new byte[]{0x1e})).build();
+        Keyexchange.ClientHello clientHello = Keyexchange.ClientHello.newBuilder()
+                .setBuildInfo(Version.standardBuildInfo())
+                .addCryptosuitesSupported(Keyexchange.Cryptosuite.CRYPTO_SUITE_SHANNON)
+                .setLoginCryptoHello(Keyexchange.LoginCryptoHelloUnion.newBuilder()
+                        .setDiffieHellman(Keyexchange.LoginCryptoDiffieHellmanHello.newBuilder()
+                                .setGc(ByteString.copyFrom(keys.publicKeyArray()))
+                                .setServerKeysKnown(1)
+                                .build())
+                        .build())
+                .setClientNonce(ByteString.copyFrom(nonce))
+                .setPadding(ByteString.copyFrom(new byte[]{0x1e}))
+                .build();
 
         byte[] clientHelloBytes = clientHello.toByteArray();
         int length = 2 + 4 + clientHelloBytes.length;
@@ -185,6 +198,7 @@ public final class Session implements Closeable, SubListener {
         acc.writeInt(length);
         acc.write(clientHelloBytes);
 
+
         // Read APResponseMessage
 
         length = conn.in.readInt();
@@ -197,6 +211,7 @@ public final class Session implements Closeable, SubListener {
         Keyexchange.APResponseMessage apResponseMessage = Keyexchange.APResponseMessage.parseFrom(buffer);
         byte[] sharedKey = Utils.toByteArray(keys.computeSharedKey(apResponseMessage.getChallenge().getLoginCryptoChallenge().getDiffieHellman().getGs().toByteArray()));
 
+
         // Check gs_signature
 
         KeyFactory factory = KeyFactory.getInstance("RSA");
@@ -207,6 +222,7 @@ public final class Session implements Closeable, SubListener {
         sig.update(apResponseMessage.getChallenge().getLoginCryptoChallenge().getDiffieHellman().getGs().toByteArray());
         if (!sig.verify(apResponseMessage.getChallenge().getLoginCryptoChallenge().getDiffieHellman().getGsSignature().toByteArray()))
             throw new GeneralSecurityException("Failed signature check!");
+
 
         // Solve challenge
 
@@ -227,9 +243,14 @@ public final class Session implements Closeable, SubListener {
         mac.update(acc.array());
 
         byte[] challenge = mac.doFinal();
-        Keyexchange.ClientResponsePlaintext clientResponsePlaintext = Keyexchange.ClientResponsePlaintext.newBuilder().setLoginCryptoResponse(
-                Keyexchange.LoginCryptoResponseUnion.newBuilder().setDiffieHellman(Keyexchange.LoginCryptoDiffieHellmanResponse.newBuilder().setHmac(ByteString.copyFrom(challenge)).build())
-                        .build()).setPowResponse(Keyexchange.PoWResponseUnion.newBuilder().build()).setCryptoResponse(Keyexchange.CryptoResponseUnion.newBuilder().build()).build();
+        Keyexchange.ClientResponsePlaintext clientResponsePlaintext = Keyexchange.ClientResponsePlaintext.newBuilder()
+                .setLoginCryptoResponse(Keyexchange.LoginCryptoResponseUnion.newBuilder()
+                        .setDiffieHellman(Keyexchange.LoginCryptoDiffieHellmanResponse.newBuilder()
+                                .setHmac(ByteString.copyFrom(challenge)).build())
+                        .build())
+                .setPowResponse(Keyexchange.PoWResponseUnion.newBuilder().build())
+                .setCryptoResponse(Keyexchange.CryptoResponseUnion.newBuilder().build())
+                .build();
 
         byte[] clientResponsePlaintextBytes = clientResponsePlaintext.toByteArray();
         length = 4 + clientResponsePlaintextBytes.length;
@@ -254,7 +275,6 @@ public final class Session implements Closeable, SubListener {
         } finally {
             conn.socket.setSoTimeout(0);
         }
-
 
         synchronized (authLock) {
             // Init Shannon cipher
@@ -310,15 +330,18 @@ public final class Session implements Closeable, SubListener {
      *                   {@code true} for {@link Session#reconnect()}.
      */
     private void authenticatePartial(@NotNull Authentication.LoginCredentials credentials, boolean removeLock) throws IOException, GeneralSecurityException, SpotifyAuthenticationException {
-        if (cipherPair == null)
-            throw new IllegalStateException("Connection not established!");
+        if (cipherPair == null) throw new IllegalStateException("Connection not established!");
 
         Authentication.ClientResponseEncrypted clientResponseEncrypted = Authentication.ClientResponseEncrypted.newBuilder()
                 .setLoginCredentials(credentials)
                 .setSystemInfo(Authentication.SystemInfo.newBuilder()
                         .setOs(Authentication.Os.OS_UNKNOWN)
                         .setCpuFamily(Authentication.CpuFamily.CPU_UNKNOWN)
-                        .setSystemInformationString(Version.systemInfoString()).setDeviceId(inner.deviceId).build()).setVersionString(Version.versionString()).build();
+                        .setSystemInformationString(Version.systemInfoString())
+                        .setDeviceId(inner.deviceId)
+                        .build())
+                .setVersionString(Version.versionString())
+                .build();
 
         sendUnchecked(Packet.Type.Login, clientResponseEncrypted.toByteArray());
 
@@ -356,8 +379,7 @@ public final class Session implements Closeable, SubListener {
                 obj.addProperty("type", reusableType.name());
 
                 File storeFile = conf().credentialsFile();
-                if (storeFile == null)
-                    throw new IllegalArgumentException();
+                if (storeFile == null) throw new IllegalArgumentException();
                 try (FileOutputStream out = new FileOutputStream(storeFile)) {
                     out.write(obj.toString().getBytes());
                 }
@@ -371,10 +393,6 @@ public final class Session implements Closeable, SubListener {
 
     @Override
     public void close() throws IOException {
-        LOGGER.info(String.format("Closing session. {deviceId: %s} ", inner.deviceId));
-
-        scheduler.shutdownNow();
-
         if (receiver != null) {
             receiver.stop();
             receiver = null;
@@ -406,11 +424,7 @@ public final class Session implements Closeable, SubListener {
         }
 
         executorService.shutdown();
-
-        if (conn != null) {
-            conn.socket.close();
-            conn = null;
-        }
+        conn.socket.close();
 
         synchronized (authLock) {
             apWelcome = null;
@@ -426,7 +440,7 @@ public final class Session implements Closeable, SubListener {
             }
         }
 
-        LOGGER.info(String.format("Closed session. {deviceId: %s} ", inner.deviceId));
+        LOGGER.info(String.format("Closed session. {deviceId: %s, ap: %s} ", inner.deviceId, conn.socket.getInetAddress()));
     }
 
     private void sendUnchecked(Packet.Type cmd, byte[] payload) throws IOException {
@@ -466,88 +480,77 @@ public final class Session implements Closeable, SubListener {
     @NotNull
     public MercuryClient mercury() {
         waitAuthLock();
-        if (mercuryClient == null)
-            throw new IllegalStateException("Session isn't authenticated!");
+        if (mercuryClient == null) throw new IllegalStateException("Session isn't authenticated!");
         return mercuryClient;
     }
 
     @NotNull
     public AudioKeyManager audioKey() {
         waitAuthLock();
-        if (audioKeyManager == null)
-            throw new IllegalStateException("Session isn't authenticated!");
+        if (audioKeyManager == null) throw new IllegalStateException("Session isn't authenticated!");
         return audioKeyManager;
     }
 
     @NotNull
     public CacheManager cache() {
         waitAuthLock();
-        if (cacheManager == null)
-            throw new IllegalStateException("Session isn't authenticated!");
+        if (cacheManager == null) throw new IllegalStateException("Session isn't authenticated!");
         return cacheManager;
     }
 
     @NotNull
     public CdnManager cdn() {
         waitAuthLock();
-        if (cdnManager == null)
-            throw new IllegalStateException("Session isn't authenticated!");
+        if (cdnManager == null) throw new IllegalStateException("Session isn't authenticated!");
         return cdnManager;
     }
 
     @NotNull
     public ChannelManager channel() {
         waitAuthLock();
-        if (channelManager == null)
-            throw new IllegalStateException("Session isn't authenticated!");
+        if (channelManager == null) throw new IllegalStateException("Session isn't authenticated!");
         return channelManager;
     }
 
     @NotNull
     public TokenProvider tokens() {
         waitAuthLock();
-        if (tokenProvider == null)
-            throw new IllegalStateException("Session isn't authenticated!");
+        if (tokenProvider == null) throw new IllegalStateException("Session isn't authenticated!");
         return tokenProvider;
     }
 
     @NotNull
     public DealerClient dealer() {
         waitAuthLock();
-        if (dealer == null)
-            throw new IllegalStateException("Session isn't authenticated!");
+        if (dealer == null) throw new IllegalStateException("Session isn't authenticated!");
         return dealer;
     }
 
     @NotNull
     public ApiClient api() {
         waitAuthLock();
-        if (api == null)
-            throw new IllegalStateException("Session isn't authenticated!");
+        if (api == null) throw new IllegalStateException("Session isn't authenticated!");
         return api;
     }
 
     @NotNull
     public PlayableContentFeeder contentFeeder() {
         waitAuthLock();
-        if (contentFeeder == null)
-            throw new IllegalStateException("Session isn't authenticated!");
+        if (contentFeeder == null) throw new IllegalStateException("Session isn't authenticated!");
         return contentFeeder;
     }
 
     @NotNull
     public Player player() {
         waitAuthLock();
-        if (player == null)
-            throw new IllegalStateException("Session isn't authenticated!");
+        if (player == null) throw new IllegalStateException("Session isn't authenticated!");
         return player;
     }
 
     @NotNull
     public SearchManager search() {
         waitAuthLock();
-        if (search == null)
-            throw new IllegalStateException("Session isn't authenticated!");
+        if (search == null) throw new IllegalStateException("Session isn't authenticated!");
         return search;
     }
 
@@ -559,14 +562,12 @@ public final class Session implements Closeable, SubListener {
     @NotNull
     public Authentication.APWelcome apWelcome() {
         waitAuthLock();
-        if (apWelcome == null)
-            throw new IllegalStateException("Session isn't authenticated!");
+        if (apWelcome == null) throw new IllegalStateException("Session isn't authenticated!");
         return apWelcome;
     }
 
     public boolean valid() {
-        if (closed)
-            return false;
+        if (closed) return false;
 
         waitAuthLock();
         return apWelcome != null && conn != null && !conn.socket.isClosed();
@@ -586,7 +587,8 @@ public final class Session implements Closeable, SubListener {
         return inner.deviceType;
     }
 
-    @NotNull ExecutorService executor() {
+    @NotNull
+    ExecutorService executor() {
         return executorService;
     }
 
@@ -613,8 +615,11 @@ public final class Session implements Closeable, SubListener {
 
             conn = ConnectionHolder.create(ApResolver.getRandomAccesspoint(), conf());
             connect();
-            authenticatePartial(Authentication.LoginCredentials.newBuilder().setUsername(apWelcome.getCanonicalUsername()).setTyp(apWelcome.getReusableAuthCredentialsType())
-                    .setAuthData(apWelcome.getReusableAuthCredentials()).build(), true);
+            authenticatePartial(Authentication.LoginCredentials.newBuilder()
+                    .setUsername(apWelcome.getCanonicalUsername())
+                    .setTyp(apWelcome.getReusableAuthCredentialsType())
+                    .setAuthData(apWelcome.getReusableAuthCredentials())
+                    .build(), true);
 
             LOGGER.info(String.format("Re-authenticated as %s!", apWelcome.getCanonicalUsername()));
 
@@ -639,13 +644,11 @@ public final class Session implements Closeable, SubListener {
     }
 
     public void addCloseListener(@NotNull CloseListener listener) {
-        if (!closeListeners.contains(listener))
-            closeListeners.add(listener);
+        if (!closeListeners.contains(listener)) closeListeners.add(listener);
     }
 
     public void addReconnectionListener(@NotNull ReconnectionListener listener) {
-        if (!reconnectionListeners.contains(listener))
-            reconnectionListeners.add(listener);
+        if (!reconnectionListeners.contains(listener)) reconnectionListeners.add(listener);
     }
 
     private void parseProductInfo(@NotNull InputStream in) throws IOException, SAXException, ParserConfigurationException {
@@ -704,17 +707,21 @@ public final class Session implements Closeable, SubListener {
     public interface ProxyConfiguration {
         boolean proxyEnabled();
 
-        @NotNull Proxy.Type proxyType();
+        @NotNull
+        Proxy.Type proxyType();
 
-        @NotNull String proxyAddress();
+        @NotNull
+        String proxyAddress();
 
         int proxyPort();
 
         boolean proxyAuth();
 
-        @NotNull String proxyUsername();
+        @NotNull
+        String proxyUsername();
 
-        @NotNull String proxyPassword();
+        @NotNull
+        String proxyPassword();
     }
 
     public interface CloseListener {
@@ -735,7 +742,8 @@ public final class Session implements Closeable, SubListener {
             this.random = new SecureRandom();
 
             String configuredDeviceId = configuration.deviceId();
-            this.deviceId = (configuredDeviceId == null || configuredDeviceId.isEmpty()) ? Utils.randomHexString(random, 40).toLowerCase() : configuredDeviceId;
+            this.deviceId = (configuredDeviceId == null || configuredDeviceId.isEmpty()) ?
+                    Utils.randomHexString(random, 40).toLowerCase() : configuredDeviceId;
         }
 
         @NotNull
@@ -757,7 +765,10 @@ public final class Session implements Closeable, SubListener {
             byte[] secret = MessageDigest.getInstance("SHA-1").digest(deviceId.getBytes());
             byte[] baseKey = PBKDF2.HmacSHA1(secret, username.getBytes(), 0x100, 20);
 
-            byte[] key = ByteBuffer.allocate(24).put(MessageDigest.getInstance("SHA-1").digest(baseKey)).putInt(20).array();
+            byte[] key = ByteBuffer.allocate(24)
+                    .put(MessageDigest.getInstance("SHA-1").digest(baseKey))
+                    .putInt(20)
+                    .array();
 
             Cipher aes = Cipher.getInstance("AES/ECB/NoPadding");
             aes.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"));
@@ -784,7 +795,11 @@ public final class Session implements Closeable, SubListener {
             byte[] authData = new byte[len];
             blob.get(authData);
 
-            return Authentication.LoginCredentials.newBuilder().setUsername(username).setTyp(type).setAuthData(ByteString.copyFrom(authData)).build();
+            return Authentication.LoginCredentials.newBuilder()
+                    .setUsername(username)
+                    .setTyp(type)
+                    .setAuthData(ByteString.copyFrom(authData))
+                    .build();
         }
     }
 
@@ -839,8 +854,11 @@ public final class Session implements Closeable, SubListener {
          */
         @NotNull
         public Builder userPass(@NotNull String username, @NotNull String password) {
-            loginCredentials = Authentication.LoginCredentials.newBuilder().setUsername(username).setTyp(Authentication.AuthenticationType.AUTHENTICATION_USER_PASS)
-                    .setAuthData(ByteString.copyFromUtf8(password)).build();
+            loginCredentials = Authentication.LoginCredentials.newBuilder()
+                    .setUsername(username)
+                    .setTyp(Authentication.AuthenticationType.AUTHENTICATION_USER_PASS)
+                    .setAuthData(ByteString.copyFromUtf8(password))
+                    .build();
             return this;
         }
 
@@ -853,8 +871,11 @@ public final class Session implements Closeable, SubListener {
                 File storeFile = authConf.credentialsFile();
                 if (storeFile != null && storeFile.exists()) {
                     JsonObject obj = JsonParser.parseReader(new FileReader(storeFile)).getAsJsonObject();
-                    loginCredentials = Authentication.LoginCredentials.newBuilder().setTyp(Authentication.AuthenticationType.valueOf(obj.get("type").getAsString()))
-                            .setUsername(obj.get("username").getAsString()).setAuthData(Utils.fromBase64(obj.get("credentials").getAsString())).build();
+                    loginCredentials = Authentication.LoginCredentials.newBuilder()
+                            .setTyp(Authentication.AuthenticationType.valueOf(obj.get("type").getAsString()))
+                            .setUsername(obj.get("username").getAsString())
+                            .setAuthData(Utils.fromBase64(obj.get("credentials").getAsString()))
+                            .build();
                 }
             }
 
@@ -868,17 +889,13 @@ public final class Session implements Closeable, SubListener {
                         facebook();
                         break;
                     case BLOB:
-                        if (username == null)
-                            throw new IllegalArgumentException("Missing authUsername!");
-                        if (blob == null)
-                            throw new IllegalArgumentException("Missing authBlob!");
+                        if (username == null) throw new IllegalArgumentException("Missing authUsername!");
+                        if (blob == null) throw new IllegalArgumentException("Missing authBlob!");
                         blob(username, Base64.getDecoder().decode(blob));
                         break;
                     case USER_PASS:
-                        if (username == null)
-                            throw new IllegalArgumentException("Missing authUsername!");
-                        if (password == null)
-                            throw new IllegalArgumentException("Missing authPassword!");
+                        if (username == null) throw new IllegalArgumentException("Missing authUsername!");
+                        if (password == null) throw new IllegalArgumentException("Missing authPassword!");
                         userPass(username, password);
                         break;
                     case ZEROCONF:
@@ -913,7 +930,8 @@ public final class Session implements Closeable, SubListener {
             this.close();
         }
 
-        @NotNull byte[] array() {
+        @NotNull
+        byte[] array() {
             return bytes;
         }
     }
@@ -953,8 +971,7 @@ public final class Session implements Closeable, SubListener {
                     out.flush();
 
                     String sl = Utils.readLine(in);
-                    if (!sl.contains("200"))
-                        throw new IOException("Failed connecting: " + sl);
+                    if (!sl.contains("200")) throw new IOException("Failed connecting: " + sl);
 
                     //noinspection StatementWithEmptyBody
                     while (!Utils.readLine(in).isEmpty()) {
@@ -993,20 +1010,16 @@ public final class Session implements Closeable, SubListener {
 
     private class Receiver implements Runnable {
         private volatile boolean shouldStop = false;
-        private Thread thread;
 
         private Receiver() {
         }
 
         void stop() {
             shouldStop = true;
-            thread.interrupt();
         }
 
         @Override
         public void run() {
-            LOGGER.trace("Session.Receiver started");
-            this.thread = Thread.currentThread();
             while (!shouldStop) {
                 Packet packet;
                 Packet.Type cmd;
@@ -1023,15 +1036,14 @@ public final class Session implements Closeable, SubListener {
                         reconnect();
                     }
 
-                    break;
+                    return;
                 }
 
-                if (shouldStop) break;
+                if (shouldStop) return;
 
                 switch (cmd) {
                     case Ping:
-                        if (scheduledReconnect != null)
-                            scheduledReconnect.cancel(true);
+                        if (scheduledReconnect != null) scheduledReconnect.cancel(true);
                         scheduledReconnect = scheduler.schedule(() -> {
                             LOGGER.warn("Socket timed out. Reconnecting...");
                             reconnect();
@@ -1092,8 +1104,6 @@ public final class Session implements Closeable, SubListener {
                         break;
                 }
             }
-
-            LOGGER.trace("Session.Receiver stopped");
         }
     }
 }

--- a/core/src/main/java/xyz/gianlu/librespot/core/Session.java
+++ b/core/src/main/java/xyz/gianlu/librespot/core/Session.java
@@ -393,6 +393,10 @@ public final class Session implements Closeable, SubListener {
 
     @Override
     public void close() throws IOException {
+		LOGGER.info(String.format("Closing session. {deviceId: %s} ", inner.deviceId));
+
+		scheduler.shutdownNow();
+
         if (receiver != null) {
             receiver.stop();
             receiver = null;
@@ -424,7 +428,11 @@ public final class Session implements Closeable, SubListener {
         }
 
         executorService.shutdown();
-        conn.socket.close();
+
+		if (conn != null) {
+            conn.socket.close();
+            conn = null;
+		}
 
         synchronized (authLock) {
             apWelcome = null;
@@ -440,7 +448,7 @@ public final class Session implements Closeable, SubListener {
             }
         }
 
-        LOGGER.info(String.format("Closed session. {deviceId: %s, ap: %s} ", inner.deviceId, conn.socket.getInetAddress()));
+		LOGGER.info(String.format("Closed session. {deviceId: %s} ", inner.deviceId));
     }
 
     private void sendUnchecked(Packet.Type cmd, byte[] payload) throws IOException {
@@ -1010,16 +1018,20 @@ public final class Session implements Closeable, SubListener {
 
     private class Receiver implements Runnable {
         private volatile boolean shouldStop = false;
+		private Thread thread;
 
         private Receiver() {
         }
 
         void stop() {
             shouldStop = true;
+			thread.interrupt();
         }
 
         @Override
         public void run() {
+			LOGGER.trace("Session.Receiver started");
+			this.thread = Thread.currentThread();
             while (!shouldStop) {
                 Packet packet;
                 Packet.Type cmd;
@@ -1036,10 +1048,10 @@ public final class Session implements Closeable, SubListener {
                         reconnect();
                     }
 
-                    return;
+					break;
                 }
 
-                if (shouldStop) return;
+				if (shouldStop) break;
 
                 switch (cmd) {
                     case Ping:
@@ -1104,6 +1116,8 @@ public final class Session implements Closeable, SubListener {
                         break;
                 }
             }
+
+			LOGGER.trace("Session.Receiver stopped");
         }
     }
 }

--- a/core/src/main/java/xyz/gianlu/librespot/dealer/DealerClient.java
+++ b/core/src/main/java/xyz/gianlu/librespot/dealer/DealerClient.java
@@ -26,19 +26,19 @@ import java.util.zip.GZIPInputStream;
  * @author Gianlu
  */
 public class DealerClient implements Closeable {
-	private static final Logger LOGGER = Logger.getLogger(DealerClient.class);
-	private final Looper looper = new Looper();
-	private final Session session;
-	private final Map<String, RequestListener> reqListeners = new HashMap<>();
-	private final Map<MessageListener, List<String>> msgListeners = new HashMap<>();
-	private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(new NameThreadFactory((r) -> "dealer-scheduler-" + r.hashCode()));
-	private final AtomicReference<ConnectionHolder> conn = new AtomicReference<>();
-	private ScheduledFuture<?> lastScheduledReconnection;
+    private static final Logger LOGGER = Logger.getLogger(DealerClient.class);
+    private final Looper looper = new Looper();
+    private final Session session;
+    private final Map<String, RequestListener> reqListeners = new HashMap<>();
+    private final Map<MessageListener, List<String>> msgListeners = new HashMap<>();
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(new NameThreadFactory((r) -> "dealer-scheduler-" + r.hashCode()));
+    private final AtomicReference<ConnectionHolder> conn = new AtomicReference<>();
+    private ScheduledFuture<?> lastScheduledReconnection;
 
-	public DealerClient(@NotNull Session session) {
-		this.session = session;
-		new Thread(looper, "dealer-looper").start();
-	}
+    public DealerClient(@NotNull Session session) {
+        this.session = session;
+        new Thread(looper, "dealer-looper").start();
+    }
 
     @NotNull
     private static Map<String, String> getHeaders(@NotNull JsonObject obj) {
@@ -50,32 +50,32 @@ public class DealerClient implements Closeable {
         return map;
     }
 
-	/**
-	 * Creates a new WebSocket client. <b>Intended for internal use only!</b>
-	 */
-	public void connect() throws IOException, MercuryClient.MercuryException {
-		conn.set(new ConnectionHolder(session,
-				new Request.Builder().url(String.format("wss://%s/?access_token=%s", ApResolver.getRandomDealer(), session.tokens().get("playlist-read"))).build()));
-	}
+    /**
+     * Creates a new WebSocket client. <b>Intended for internal use only!</b>
+     */
+    public void connect() throws IOException, MercuryClient.MercuryException {
+        conn.set(new ConnectionHolder(session,
+                new Request.Builder().url(String.format("wss://%s/?access_token=%s", ApResolver.getRandomDealer(), session.tokens().get("playlist-read"))).build()));
+    }
 
-	private void waitForListeners() {
-		synchronized (msgListeners) {
-			if (!msgListeners.isEmpty())
-				return;
+    private void waitForListeners() {
+        synchronized (msgListeners) {
+            if (!msgListeners.isEmpty())
+                return;
 
-			try {
-				msgListeners.wait();
-			} catch (InterruptedException ignored) {
-			}
-		}
-	}
+            try {
+                msgListeners.wait();
+            } catch (InterruptedException ignored) {
+            }
+        }
+    }
 
-	private void handleRequest(@NotNull JsonObject obj) {
-		String mid = obj.get("message_ident").getAsString();
-		String key = obj.get("key").getAsString();
+    private void handleRequest(@NotNull JsonObject obj) {
+        String mid = obj.get("message_ident").getAsString();
+        String key = obj.get("key").getAsString();
 
         Map<String, String> headers = getHeaders(obj);
-		JsonObject payload = obj.getAsJsonObject("payload");
+        JsonObject payload = obj.getAsJsonObject("payload");
         if ("gzip".equals(headers.get("Transfer-Encoding"))) {
             byte[] gzip = Base64.getDecoder().decode(payload.get("compressed").getAsString());
             try (GZIPInputStream in = new GZIPInputStream(new ByteArrayInputStream(gzip))) {
@@ -86,308 +86,308 @@ public class DealerClient implements Closeable {
             }
         }
 
-		int pid = payload.get("message_id").getAsInt();
-		String sender = payload.get("sent_by_device_id").getAsString();
+        int pid = payload.get("message_id").getAsInt();
+        String sender = payload.get("sent_by_device_id").getAsString();
 
-		JsonObject command = payload.getAsJsonObject("command");
-		LOGGER.trace(String.format("Received request. {mid: %s, key: %s, pid: %d, sender: %s}", mid, key, pid, sender));
+        JsonObject command = payload.getAsJsonObject("command");
+        LOGGER.trace(String.format("Received request. {mid: %s, key: %s, pid: %d, sender: %s}", mid, key, pid, sender));
 
-		boolean interesting = false;
-		synchronized (reqListeners) {
-			for (String midPrefix : reqListeners.keySet()) {
-				if (mid.startsWith(midPrefix)) {
-					RequestListener listener = reqListeners.get(midPrefix);
-					interesting = true;
-					looper.submit(() -> {
-						RequestResult result = listener.onRequest(mid, pid, sender, command);
-						conn.get().sendReply(key, result);
-						LOGGER.debug(String.format("Handled request. {key: %s, result: %s}", key, result));
-					});
-				}
-			}
-		}
+        boolean interesting = false;
+        synchronized (reqListeners) {
+            for (String midPrefix : reqListeners.keySet()) {
+                if (mid.startsWith(midPrefix)) {
+                    RequestListener listener = reqListeners.get(midPrefix);
+                    interesting = true;
+                    looper.submit(() -> {
+                        RequestResult result = listener.onRequest(mid, pid, sender, command);
+                        conn.get().sendReply(key, result);
+                        LOGGER.debug(String.format("Handled request. {key: %s, result: %s}", key, result));
+                    });
+                }
+            }
+        }
 
-		if (!interesting)
-			LOGGER.debug("Couldn't dispatch request: " + mid);
-	}
+        if (!interesting)
+            LOGGER.debug("Couldn't dispatch request: " + mid);
+    }
 
-	private void handleMessage(@NotNull JsonObject obj) {
-		String uri = obj.get("uri").getAsString();
+    private void handleMessage(@NotNull JsonObject obj) {
+        String uri = obj.get("uri").getAsString();
 
-		Map<String, String> headers = getHeaders(obj);
-		JsonArray payloads = obj.getAsJsonArray("payloads");
-		byte[] decodedPayload;
-		if (payloads != null) {
-			String[] payloadsStr = new String[payloads.size()];
-			for (int i = 0; i < payloads.size(); i++) payloadsStr[i] = payloads.get(i).getAsString();
+        Map<String, String> headers = getHeaders(obj);
+        JsonArray payloads = obj.getAsJsonArray("payloads");
+        byte[] decodedPayload;
+        if (payloads != null) {
+            String[] payloadsStr = new String[payloads.size()];
+            for (int i = 0; i < payloads.size(); i++) payloadsStr[i] = payloads.get(i).getAsString();
 
-			InputStream in = BytesArrayList.streamBase64(payloadsStr);
-			if ("gzip".equals(headers.get("Transfer-Encoding"))) {
-				try {
-					in = new GZIPInputStream(in);
-				} catch (IOException ex) {
-					LOGGER.warn(String.format("Failed decompressing message! {uri: %s}", uri), ex);
-					return;
-				}
-			}
+            InputStream in = BytesArrayList.streamBase64(payloadsStr);
+            if ("gzip".equals(headers.get("Transfer-Encoding"))) {
+                try {
+                    in = new GZIPInputStream(in);
+                } catch (IOException ex) {
+                    LOGGER.warn(String.format("Failed decompressing message! {uri: %s}", uri), ex);
+                    return;
+                }
+            }
 
-			try {
-				ByteArrayOutputStream out = new ByteArrayOutputStream(in.available());
-				byte[] buffer = new byte[1024];
-				int read;
-				while ((read = in.read(buffer)) != -1) out.write(buffer, 0, read);
-				decodedPayload = out.toByteArray();
-			} catch (IOException ex) {
-				throw new IllegalStateException(ex);
-			} finally {
-				try {
-					in.close();
-				} catch (IOException ignored) {
-				}
-			}
-		} else {
-			decodedPayload = new byte[0];
-		}
+            try {
+                ByteArrayOutputStream out = new ByteArrayOutputStream(in.available());
+                byte[] buffer = new byte[1024];
+                int read;
+                while ((read = in.read(buffer)) != -1) out.write(buffer, 0, read);
+                decodedPayload = out.toByteArray();
+            } catch (IOException ex) {
+                throw new IllegalStateException(ex);
+            } finally {
+                try {
+                    in.close();
+                } catch (IOException ignored) {
+                }
+            }
+        } else {
+            decodedPayload = new byte[0];
+        }
 
-		boolean interesting = false;
-		synchronized (msgListeners) {
-			for (MessageListener listener : msgListeners.keySet()) {
-				boolean dispatched = false;
-				List<String> keys = msgListeners.get(listener);
-				for (String key : keys) {
-					if (uri.startsWith(key) && !dispatched) {
-						interesting = true;
-						looper.submit(() -> {
-							try {
-								listener.onMessage(uri, headers, decodedPayload);
-							} catch (IOException ex) {
-								LOGGER.error("Failed dispatching message!", ex);
-							}
-						});
-						dispatched = true;
-					}
-				}
-			}
-		}
+        boolean interesting = false;
+        synchronized (msgListeners) {
+            for (MessageListener listener : msgListeners.keySet()) {
+                boolean dispatched = false;
+                List<String> keys = msgListeners.get(listener);
+                for (String key : keys) {
+                    if (uri.startsWith(key) && !dispatched) {
+                        interesting = true;
+                        looper.submit(() -> {
+                            try {
+                                listener.onMessage(uri, headers, decodedPayload);
+                            } catch (IOException ex) {
+                                LOGGER.error("Failed dispatching message!", ex);
+                            }
+                        });
+                        dispatched = true;
+                    }
+                }
+            }
+        }
 
-		if (!interesting) LOGGER.debug("Couldn't dispatch message: " + uri);
-	}
+        if (!interesting) LOGGER.debug("Couldn't dispatch message: " + uri);
+    }
 
-	public void addMessageListener(@NotNull MessageListener listener, @NotNull String... uris) {
-		synchronized (msgListeners) {
+    public void addMessageListener(@NotNull MessageListener listener, @NotNull String... uris) {
+        synchronized (msgListeners) {
             if (msgListeners.containsKey(listener))
                 throw new IllegalArgumentException(String.format("A listener for %s has already been added.", Arrays.toString(uris)));
 
-			msgListeners.put(listener, Arrays.asList(uris));
-			msgListeners.notifyAll();
-		}
-	}
+            msgListeners.put(listener, Arrays.asList(uris));
+            msgListeners.notifyAll();
+        }
+    }
 
-	public void removeMessageListener(@NotNull MessageListener listener) {
-		synchronized (msgListeners) {
-			msgListeners.remove(listener);
-		}
-	}
+    public void removeMessageListener(@NotNull MessageListener listener) {
+        synchronized (msgListeners) {
+            msgListeners.remove(listener);
+        }
+    }
 
-	public void addRequestListener(@NotNull RequestListener listener, @NotNull String uri) {
-		synchronized (reqListeners) {
-			if (reqListeners.containsKey(uri))
-				throw new IllegalArgumentException(String.format("A listener for '%s' has already been added.", uri));
+    public void addRequestListener(@NotNull RequestListener listener, @NotNull String uri) {
+        synchronized (reqListeners) {
+            if (reqListeners.containsKey(uri))
+                throw new IllegalArgumentException(String.format("A listener for '%s' has already been added.", uri));
 
-			reqListeners.put(uri, listener);
-			reqListeners.notifyAll();
-		}
-	}
+            reqListeners.put(uri, listener);
+            reqListeners.notifyAll();
+        }
+    }
 
-	public void removeRequestListener(@NotNull RequestListener listener) {
-		synchronized (reqListeners) {
-			reqListeners.values().remove(listener);
-		}
-	}
+    public void removeRequestListener(@NotNull RequestListener listener) {
+        synchronized (reqListeners) {
+            reqListeners.values().remove(listener);
+        }
+    }
 
-	@Override
-	public void close() {
-		looper.close();
-		scheduler.shutdown();
+    @Override
+    public void close() {
+        looper.close();
+        scheduler.shutdown();
 
-		if (conn.get() != null) {
-			ConnectionHolder tmp = conn.get(); // Do not trigger connectionInvalided()
-			conn.set(null);
-			tmp.close();
-		}
+        if (conn.get() != null) {
+            ConnectionHolder tmp = conn.get(); // Do not trigger connectionInvalided()
+            conn.set(null);
+            tmp.close();
+        }
 
-		if (lastScheduledReconnection != null) {
-			lastScheduledReconnection.cancel(true);
-			lastScheduledReconnection = null;
-		}
+        if (lastScheduledReconnection != null) {
+            lastScheduledReconnection.cancel(true);
+            lastScheduledReconnection = null;
+        }
 
-		msgListeners.clear();
-	}
+        msgListeners.clear();
+    }
 
-	/**
-	 * Called when the {@link ConnectionHolder} has been closed and cannot be used no more for a connection.
-	 */
-	private void connectionInvalided() {
-		if (lastScheduledReconnection != null && !lastScheduledReconnection.isDone())
-			throw new IllegalStateException();
+    /**
+     * Called when the {@link ConnectionHolder} has been closed and cannot be used no more for a connection.
+     */
+    private void connectionInvalided() {
+        if (lastScheduledReconnection != null && !lastScheduledReconnection.isDone())
+            throw new IllegalStateException();
 
-		conn.set(null);
+        conn.set(null);
 
-		LOGGER.trace("Scheduled reconnection attempt in 10 seconds...");
-		lastScheduledReconnection = scheduler.schedule(() -> {
-			lastScheduledReconnection = null;
+        LOGGER.trace("Scheduled reconnection attempt in 10 seconds...");
+        lastScheduledReconnection = scheduler.schedule(() -> {
+            lastScheduledReconnection = null;
 
-			try {
-				connect();
-			} catch (IOException | MercuryClient.MercuryException ex) {
-				LOGGER.error("Failed reconnecting, retrying...", ex);
-				connectionInvalided();
-			}
-		}, 10, TimeUnit.SECONDS);
-	}
+            try {
+                connect();
+            } catch (IOException | MercuryClient.MercuryException ex) {
+                LOGGER.error("Failed reconnecting, retrying...", ex);
+                connectionInvalided();
+            }
+        }, 10, TimeUnit.SECONDS);
+    }
 
-	public enum RequestResult {
-		UNKNOWN_SEND_COMMAND_RESULT, SUCCESS, DEVICE_NOT_FOUND, CONTEXT_PLAYER_ERROR, DEVICE_DISAPPEARED, UPSTREAM_ERROR, DEVICE_DOES_NOT_SUPPORT_COMMAND, RATE_LIMITED
-	}
+    public enum RequestResult {
+        UNKNOWN_SEND_COMMAND_RESULT, SUCCESS, DEVICE_NOT_FOUND, CONTEXT_PLAYER_ERROR, DEVICE_DISAPPEARED, UPSTREAM_ERROR, DEVICE_DOES_NOT_SUPPORT_COMMAND, RATE_LIMITED
+    }
 
-	public interface RequestListener {
-		@NotNull RequestResult onRequest(@NotNull String mid, int pid, @NotNull String sender, @NotNull JsonObject command);
-	}
+    public interface RequestListener {
+        @NotNull RequestResult onRequest(@NotNull String mid, int pid, @NotNull String sender, @NotNull JsonObject command);
+    }
 
-	public interface MessageListener {
+    public interface MessageListener {
         void onMessage(@NotNull String uri, @NotNull Map<String, String> headers, @NotNull byte[] payload) throws IOException;
-	}
+    }
 
-	private static class Looper implements Runnable, Closeable {
-		private final BlockingQueue<Runnable> tasks = new LinkedBlockingQueue<>();
-		private boolean shouldStop = false;
-		private Thread thread;
+    private static class Looper implements Runnable, Closeable {
+        private final BlockingQueue<Runnable> tasks = new LinkedBlockingQueue<>();
+        private boolean shouldStop = false;
+        private Thread thread;
 
-		void submit(@NotNull Runnable task) {
-			tasks.add(task);
-		}
+        void submit(@NotNull Runnable task) {
+            tasks.add(task);
+        }
 
-		@Override
-		public void run() {
-			LOGGER.trace("DealerClient.Looper started");
-			this.thread = Thread.currentThread();
-			while (!shouldStop) {
-				try {
-					tasks.take().run();
-				} catch (InterruptedException ex) {
-					break;
-				}
-			}
-			LOGGER.trace("DealerClient.Looper stopped");
-		}
+        @Override
+        public void run() {
+            LOGGER.trace("DealerClient.Looper started");
+            this.thread = Thread.currentThread();
+            while (!shouldStop) {
+                try {
+                    tasks.take().run();
+                } catch (InterruptedException ex) {
+                    break;
+                }
+            }
+            LOGGER.trace("DealerClient.Looper stopped");
+        }
 
-		@Override
-		public void close() {
-			shouldStop = true;
-			thread.interrupt();
-		}
-	}
+        @Override
+        public void close() {
+            shouldStop = true;
+            thread.interrupt();
+        }
+    }
 
-	private class ConnectionHolder implements Closeable {
-		private final WebSocket ws;
-		private boolean closed = false;
-		private boolean receivedPong = false;
-		private ScheduledFuture<?> lastScheduledPing;
+    private class ConnectionHolder implements Closeable {
+        private final WebSocket ws;
+        private boolean closed = false;
+        private boolean receivedPong = false;
+        private ScheduledFuture<?> lastScheduledPing;
 
-		ConnectionHolder(@NotNull Session session, @NotNull Request request) {
-			ws = session.client().newWebSocket(request, new WebSocketListenerImpl());
-		}
+        ConnectionHolder(@NotNull Session session, @NotNull Request request) {
+            ws = session.client().newWebSocket(request, new WebSocketListenerImpl());
+        }
 
-		private void sendPing() {
-			ws.send("{\"type\":\"ping\"}");
-		}
+        private void sendPing() {
+            ws.send("{\"type\":\"ping\"}");
+        }
 
-		void sendReply(@NotNull String key, @NotNull RequestResult result) {
-			boolean success = result == RequestResult.SUCCESS;
-			ws.send(String.format("{\"type\":\"reply\", \"key\": \"%s\", \"payload\": {\"success\": %b}}", key, success));
-		}
+        void sendReply(@NotNull String key, @NotNull RequestResult result) {
+            boolean success = result == RequestResult.SUCCESS;
+            ws.send(String.format("{\"type\":\"reply\", \"key\": \"%s\", \"payload\": {\"success\": %b}}", key, success));
+        }
 
-		@Override
-		public void close() {
-			if (closed) {
-				ws.cancel();
-			} else {
-				closed = true;
-				ws.close(1000, null);
-			}
+        @Override
+        public void close() {
+            if (closed) {
+                ws.cancel();
+            } else {
+                closed = true;
+                ws.close(1000, null);
+            }
 
-			if (lastScheduledPing != null) {
-				lastScheduledPing.cancel(false);
-				lastScheduledPing = null;
-			}
+            if (lastScheduledPing != null) {
+                lastScheduledPing.cancel(false);
+                lastScheduledPing = null;
+            }
 
             ConnectionHolder holder = conn.get();
             if (holder == null) return;
 
             if (holder == ConnectionHolder.this)
-				connectionInvalided();
-			else
+                connectionInvalided();
+            else
                 LOGGER.debug(String.format("Did not dispatch connection invalidated: %s != %s", holder, ConnectionHolder.this));
-		}
+        }
 
-		private class WebSocketListenerImpl extends WebSocketListener {
+        private class WebSocketListenerImpl extends WebSocketListener {
 
-			@Override
-			public void onOpen(@NotNull WebSocket ws, @NotNull Response response) {
-				if (closed || scheduler.isShutdown()) {
-					LOGGER.fatal(String.format("I wonder what happened here... Terminating. {closed: %b}", closed));
-					return;
-				}
+            @Override
+            public void onOpen(@NotNull WebSocket ws, @NotNull Response response) {
+                if (closed || scheduler.isShutdown()) {
+                    LOGGER.fatal(String.format("I wonder what happened here... Terminating. {closed: %b}", closed));
+                    return;
+                }
 
-				LOGGER.debug(String.format("Dealer connected! {host: %s}", response.request().url().host()));
-				lastScheduledPing = scheduler.scheduleAtFixedRate(() -> {
-					sendPing();
-					receivedPong = false;
+                LOGGER.debug(String.format("Dealer connected! {host: %s}", response.request().url().host()));
+                lastScheduledPing = scheduler.scheduleAtFixedRate(() -> {
+                    sendPing();
+                    receivedPong = false;
 
-					scheduler.schedule(() -> {
-						if (lastScheduledPing == null || lastScheduledPing.isCancelled())
-							return;
+                    scheduler.schedule(() -> {
+                        if (lastScheduledPing == null || lastScheduledPing.isCancelled())
+                            return;
 
-						if (!receivedPong) {
-							LOGGER.warn("Did not receive ping in 3 seconds. Reconnecting...");
-							ConnectionHolder.this.close();
-							return;
-						}
+                        if (!receivedPong) {
+                            LOGGER.warn("Did not receive ping in 3 seconds. Reconnecting...");
+                            ConnectionHolder.this.close();
+                            return;
+                        }
 
-						receivedPong = false;
-					}, 3, TimeUnit.SECONDS);
-				}, 0, 30, TimeUnit.SECONDS);
-			}
+                        receivedPong = false;
+                    }, 3, TimeUnit.SECONDS);
+                }, 0, 30, TimeUnit.SECONDS);
+            }
 
-			@Override
-			public void onMessage(@NotNull WebSocket ws, @NotNull String text) {
-				JsonObject obj = JsonParser.parseString(text).getAsJsonObject();
+            @Override
+            public void onMessage(@NotNull WebSocket ws, @NotNull String text) {
+                JsonObject obj = JsonParser.parseString(text).getAsJsonObject();
 
-				waitForListeners();
+                waitForListeners();
 
-				MessageType type = MessageType.parse(obj.get("type").getAsString());
-				switch (type) {
-					case MESSAGE:
-						handleMessage(obj);
-						break;
-					case REQUEST:
-						handleRequest(obj);
-						break;
-					case PONG:
-						receivedPong = true;
-						break;
-					case PING:
-						break;
-					default:
-						throw new IllegalArgumentException("Unknown message type for " + type);
-				}
-			}
+                MessageType type = MessageType.parse(obj.get("type").getAsString());
+                switch (type) {
+                    case MESSAGE:
+                        handleMessage(obj);
+                        break;
+                    case REQUEST:
+                        handleRequest(obj);
+                        break;
+                    case PONG:
+                        receivedPong = true;
+                        break;
+                    case PING:
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unknown message type for " + type);
+                }
+            }
 
-			@Override
-			public void onFailure(@NotNull WebSocket ws, @NotNull Throwable t, @Nullable Response response) {
-				LOGGER.warn("An exception occurred. Reconnecting...", t);
-				ConnectionHolder.this.close();
-			}
-		}
-	}
+            @Override
+            public void onFailure(@NotNull WebSocket ws, @NotNull Throwable t, @Nullable Response response) {
+                LOGGER.warn("An exception occurred. Reconnecting...", t);
+                ConnectionHolder.this.close();
+            }
+        }
+    }
 }

--- a/core/src/main/java/xyz/gianlu/librespot/dealer/DealerClient.java
+++ b/core/src/main/java/xyz/gianlu/librespot/dealer/DealerClient.java
@@ -26,19 +26,19 @@ import java.util.zip.GZIPInputStream;
  * @author Gianlu
  */
 public class DealerClient implements Closeable {
-    private static final Logger LOGGER = Logger.getLogger(DealerClient.class);
-    private final Looper looper = new Looper();
-    private final Session session;
-    private final Map<String, RequestListener> reqListeners = new HashMap<>();
-    private final Map<MessageListener, List<String>> msgListeners = new HashMap<>();
-    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(new NameThreadFactory((r) -> "dealer-scheduler-" + r.hashCode()));
-    private final AtomicReference<ConnectionHolder> conn = new AtomicReference<>();
-    private ScheduledFuture<?> lastScheduledReconnection;
+	private static final Logger LOGGER = Logger.getLogger(DealerClient.class);
+	private final Looper looper = new Looper();
+	private final Session session;
+	private final Map<String, RequestListener> reqListeners = new HashMap<>();
+	private final Map<MessageListener, List<String>> msgListeners = new HashMap<>();
+	private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(new NameThreadFactory((r) -> "dealer-scheduler-" + r.hashCode()));
+	private final AtomicReference<ConnectionHolder> conn = new AtomicReference<>();
+	private ScheduledFuture<?> lastScheduledReconnection;
 
-    public DealerClient(@NotNull Session session) {
-        this.session = session;
-        new Thread(looper, "dealer-looper").start();
-    }
+	public DealerClient(@NotNull Session session) {
+		this.session = session;
+		new Thread(looper, "dealer-looper").start();
+	}
 
     @NotNull
     private static Map<String, String> getHeaders(@NotNull JsonObject obj) {
@@ -50,32 +50,32 @@ public class DealerClient implements Closeable {
         return map;
     }
 
-    /**
-     * Creates a new WebSocket client. <b>Intended for internal use only!</b>
-     */
-    public void connect() throws IOException, MercuryClient.MercuryException {
-        conn.set(new ConnectionHolder(session, new Request.Builder()
-                .url(String.format("wss://%s/?access_token=%s", ApResolver.getRandomDealer(), session.tokens().get("playlist-read")))
-                .build()));
-    }
+	/**
+	 * Creates a new WebSocket client. <b>Intended for internal use only!</b>
+	 */
+	public void connect() throws IOException, MercuryClient.MercuryException {
+		conn.set(new ConnectionHolder(session,
+				new Request.Builder().url(String.format("wss://%s/?access_token=%s", ApResolver.getRandomDealer(), session.tokens().get("playlist-read"))).build()));
+	}
 
-    private void waitForListeners() {
-        synchronized (msgListeners) {
-            if (!msgListeners.isEmpty()) return;
+	private void waitForListeners() {
+		synchronized (msgListeners) {
+			if (!msgListeners.isEmpty())
+				return;
 
-            try {
-                msgListeners.wait();
-            } catch (InterruptedException ignored) {
-            }
-        }
-    }
+			try {
+				msgListeners.wait();
+			} catch (InterruptedException ignored) {
+			}
+		}
+	}
 
-    private void handleRequest(@NotNull JsonObject obj) {
-        String mid = obj.get("message_ident").getAsString();
-        String key = obj.get("key").getAsString();
+	private void handleRequest(@NotNull JsonObject obj) {
+		String mid = obj.get("message_ident").getAsString();
+		String key = obj.get("key").getAsString();
 
         Map<String, String> headers = getHeaders(obj);
-        JsonObject payload = obj.getAsJsonObject("payload");
+		JsonObject payload = obj.getAsJsonObject("payload");
         if ("gzip".equals(headers.get("Transfer-Encoding"))) {
             byte[] gzip = Base64.getDecoder().decode(payload.get("compressed").getAsString());
             try (GZIPInputStream in = new GZIPInputStream(new ByteArrayInputStream(gzip))) {
@@ -86,303 +86,308 @@ public class DealerClient implements Closeable {
             }
         }
 
-        int pid = payload.get("message_id").getAsInt();
-        String sender = payload.get("sent_by_device_id").getAsString();
+		int pid = payload.get("message_id").getAsInt();
+		String sender = payload.get("sent_by_device_id").getAsString();
 
-        JsonObject command = payload.getAsJsonObject("command");
-        LOGGER.trace(String.format("Received request. {mid: %s, key: %s, pid: %d, sender: %s}", mid, key, pid, sender));
+		JsonObject command = payload.getAsJsonObject("command");
+		LOGGER.trace(String.format("Received request. {mid: %s, key: %s, pid: %d, sender: %s}", mid, key, pid, sender));
 
-        boolean interesting = false;
-        synchronized (reqListeners) {
-            for (String midPrefix : reqListeners.keySet()) {
-                if (mid.startsWith(midPrefix)) {
-                    RequestListener listener = reqListeners.get(midPrefix);
-                    interesting = true;
-                    looper.submit(() -> {
-                        RequestResult result = listener.onRequest(mid, pid, sender, command);
-                        conn.get().sendReply(key, result);
-                        LOGGER.debug(String.format("Handled request. {key: %s, result: %s}", key, result));
-                    });
-                }
-            }
-        }
+		boolean interesting = false;
+		synchronized (reqListeners) {
+			for (String midPrefix : reqListeners.keySet()) {
+				if (mid.startsWith(midPrefix)) {
+					RequestListener listener = reqListeners.get(midPrefix);
+					interesting = true;
+					looper.submit(() -> {
+						RequestResult result = listener.onRequest(mid, pid, sender, command);
+						conn.get().sendReply(key, result);
+						LOGGER.debug(String.format("Handled request. {key: %s, result: %s}", key, result));
+					});
+				}
+			}
+		}
 
-        if (!interesting) LOGGER.debug("Couldn't dispatch request: " + mid);
-    }
+		if (!interesting)
+			LOGGER.debug("Couldn't dispatch request: " + mid);
+	}
 
-    private void handleMessage(@NotNull JsonObject obj) {
-        String uri = obj.get("uri").getAsString();
+	private void handleMessage(@NotNull JsonObject obj) {
+		String uri = obj.get("uri").getAsString();
 
-        Map<String, String> headers = getHeaders(obj);
-        JsonArray payloads = obj.getAsJsonArray("payloads");
-        byte[] decodedPayload;
-        if (payloads != null) {
-            String[] payloadsStr = new String[payloads.size()];
-            for (int i = 0; i < payloads.size(); i++) payloadsStr[i] = payloads.get(i).getAsString();
+		Map<String, String> headers = getHeaders(obj);
+		JsonArray payloads = obj.getAsJsonArray("payloads");
+		byte[] decodedPayload;
+		if (payloads != null) {
+			String[] payloadsStr = new String[payloads.size()];
+			for (int i = 0; i < payloads.size(); i++) payloadsStr[i] = payloads.get(i).getAsString();
 
-            InputStream in = BytesArrayList.streamBase64(payloadsStr);
-            if ("gzip".equals(headers.get("Transfer-Encoding"))) {
-                try {
-                    in = new GZIPInputStream(in);
-                } catch (IOException ex) {
-                    LOGGER.warn(String.format("Failed decompressing message! {uri: %s}", uri), ex);
-                    return;
-                }
-            }
+			InputStream in = BytesArrayList.streamBase64(payloadsStr);
+			if ("gzip".equals(headers.get("Transfer-Encoding"))) {
+				try {
+					in = new GZIPInputStream(in);
+				} catch (IOException ex) {
+					LOGGER.warn(String.format("Failed decompressing message! {uri: %s}", uri), ex);
+					return;
+				}
+			}
 
-            try {
-                ByteArrayOutputStream out = new ByteArrayOutputStream(in.available());
-                byte[] buffer = new byte[1024];
-                int read;
-                while ((read = in.read(buffer)) != -1) out.write(buffer, 0, read);
-                decodedPayload = out.toByteArray();
-            } catch (IOException ex) {
-                throw new IllegalStateException(ex);
-            } finally {
-                try {
-                    in.close();
-                } catch (IOException ignored) {
-                }
-            }
-        } else {
-            decodedPayload = new byte[0];
-        }
+			try {
+				ByteArrayOutputStream out = new ByteArrayOutputStream(in.available());
+				byte[] buffer = new byte[1024];
+				int read;
+				while ((read = in.read(buffer)) != -1) out.write(buffer, 0, read);
+				decodedPayload = out.toByteArray();
+			} catch (IOException ex) {
+				throw new IllegalStateException(ex);
+			} finally {
+				try {
+					in.close();
+				} catch (IOException ignored) {
+				}
+			}
+		} else {
+			decodedPayload = new byte[0];
+		}
 
-        boolean interesting = false;
-        synchronized (msgListeners) {
-            for (MessageListener listener : msgListeners.keySet()) {
-                boolean dispatched = false;
-                List<String> keys = msgListeners.get(listener);
-                for (String key : keys) {
-                    if (uri.startsWith(key) && !dispatched) {
-                        interesting = true;
-                        looper.submit(() -> {
-                            try {
-                                listener.onMessage(uri, headers, decodedPayload);
-                            } catch (IOException ex) {
-                                LOGGER.error("Failed dispatching message!", ex);
-                            }
-                        });
-                        dispatched = true;
-                    }
-                }
-            }
-        }
+		boolean interesting = false;
+		synchronized (msgListeners) {
+			for (MessageListener listener : msgListeners.keySet()) {
+				boolean dispatched = false;
+				List<String> keys = msgListeners.get(listener);
+				for (String key : keys) {
+					if (uri.startsWith(key) && !dispatched) {
+						interesting = true;
+						looper.submit(() -> {
+							try {
+								listener.onMessage(uri, headers, decodedPayload);
+							} catch (IOException ex) {
+								LOGGER.error("Failed dispatching message!", ex);
+							}
+						});
+						dispatched = true;
+					}
+				}
+			}
+		}
 
-        if (!interesting) LOGGER.debug("Couldn't dispatch message: " + uri);
-    }
+		if (!interesting) LOGGER.debug("Couldn't dispatch message: " + uri);
+	}
 
-    public void addMessageListener(@NotNull MessageListener listener, @NotNull String... uris) {
-        synchronized (msgListeners) {
+	public void addMessageListener(@NotNull MessageListener listener, @NotNull String... uris) {
+		synchronized (msgListeners) {
             if (msgListeners.containsKey(listener))
                 throw new IllegalArgumentException(String.format("A listener for %s has already been added.", Arrays.toString(uris)));
 
-            msgListeners.put(listener, Arrays.asList(uris));
-            msgListeners.notifyAll();
-        }
-    }
+			msgListeners.put(listener, Arrays.asList(uris));
+			msgListeners.notifyAll();
+		}
+	}
 
-    public void removeMessageListener(@NotNull MessageListener listener) {
-        synchronized (msgListeners) {
-            msgListeners.remove(listener);
-        }
-    }
+	public void removeMessageListener(@NotNull MessageListener listener) {
+		synchronized (msgListeners) {
+			msgListeners.remove(listener);
+		}
+	}
 
-    public void addRequestListener(@NotNull RequestListener listener, @NotNull String uri) {
-        synchronized (reqListeners) {
-            if (reqListeners.containsKey(uri))
-                throw new IllegalArgumentException(String.format("A listener for '%s' has already been added.", uri));
+	public void addRequestListener(@NotNull RequestListener listener, @NotNull String uri) {
+		synchronized (reqListeners) {
+			if (reqListeners.containsKey(uri))
+				throw new IllegalArgumentException(String.format("A listener for '%s' has already been added.", uri));
 
-            reqListeners.put(uri, listener);
-            reqListeners.notifyAll();
-        }
-    }
+			reqListeners.put(uri, listener);
+			reqListeners.notifyAll();
+		}
+	}
 
-    public void removeRequestListener(@NotNull RequestListener listener) {
-        synchronized (reqListeners) {
-            reqListeners.values().remove(listener);
-        }
-    }
+	public void removeRequestListener(@NotNull RequestListener listener) {
+		synchronized (reqListeners) {
+			reqListeners.values().remove(listener);
+		}
+	}
 
-    @Override
-    public void close() {
-        if (conn.get() != null) {
-            ConnectionHolder tmp = conn.get(); // Do not trigger connectionInvalided()
-            conn.set(null);
-            tmp.close();
-        }
+	@Override
+	public void close() {
+		looper.close();
+		scheduler.shutdown();
 
-        if (lastScheduledReconnection != null) {
-            lastScheduledReconnection.cancel(true);
-            lastScheduledReconnection = null;
-        }
+		if (conn.get() != null) {
+			ConnectionHolder tmp = conn.get(); // Do not trigger connectionInvalided()
+			conn.set(null);
+			tmp.close();
+		}
 
-        scheduler.shutdown();
-        msgListeners.clear();
-    }
+		if (lastScheduledReconnection != null) {
+			lastScheduledReconnection.cancel(true);
+			lastScheduledReconnection = null;
+		}
 
-    /**
-     * Called when the {@link ConnectionHolder} has been closed and cannot be used no more for a connection.
-     */
-    private void connectionInvalided() {
-        if (lastScheduledReconnection != null && !lastScheduledReconnection.isDone())
-            throw new IllegalStateException();
+		msgListeners.clear();
+	}
 
-        conn.set(null);
+	/**
+	 * Called when the {@link ConnectionHolder} has been closed and cannot be used no more for a connection.
+	 */
+	private void connectionInvalided() {
+		if (lastScheduledReconnection != null && !lastScheduledReconnection.isDone())
+			throw new IllegalStateException();
 
-        LOGGER.trace("Scheduled reconnection attempt in 10 seconds...");
-        lastScheduledReconnection = scheduler.schedule(() -> {
-            lastScheduledReconnection = null;
+		conn.set(null);
 
-            try {
-                connect();
-            } catch (IOException | MercuryClient.MercuryException ex) {
-                LOGGER.error("Failed reconnecting, retrying...", ex);
-                connectionInvalided();
-            }
-        }, 10, TimeUnit.SECONDS);
-    }
+		LOGGER.trace("Scheduled reconnection attempt in 10 seconds...");
+		lastScheduledReconnection = scheduler.schedule(() -> {
+			lastScheduledReconnection = null;
 
-    public enum RequestResult {
-        UNKNOWN_SEND_COMMAND_RESULT, SUCCESS,
-        DEVICE_NOT_FOUND, CONTEXT_PLAYER_ERROR,
-        DEVICE_DISAPPEARED, UPSTREAM_ERROR,
-        DEVICE_DOES_NOT_SUPPORT_COMMAND, RATE_LIMITED
-    }
+			try {
+				connect();
+			} catch (IOException | MercuryClient.MercuryException ex) {
+				LOGGER.error("Failed reconnecting, retrying...", ex);
+				connectionInvalided();
+			}
+		}, 10, TimeUnit.SECONDS);
+	}
 
-    public interface RequestListener {
-        @NotNull
-        RequestResult onRequest(@NotNull String mid, int pid, @NotNull String sender, @NotNull JsonObject command);
-    }
+	public enum RequestResult {
+		UNKNOWN_SEND_COMMAND_RESULT, SUCCESS, DEVICE_NOT_FOUND, CONTEXT_PLAYER_ERROR, DEVICE_DISAPPEARED, UPSTREAM_ERROR, DEVICE_DOES_NOT_SUPPORT_COMMAND, RATE_LIMITED
+	}
 
-    public interface MessageListener {
+	public interface RequestListener {
+		@NotNull RequestResult onRequest(@NotNull String mid, int pid, @NotNull String sender, @NotNull JsonObject command);
+	}
+
+	public interface MessageListener {
         void onMessage(@NotNull String uri, @NotNull Map<String, String> headers, @NotNull byte[] payload) throws IOException;
-    }
+	}
 
-    private static class Looper implements Runnable, Closeable {
-        private final BlockingQueue<Runnable> tasks = new LinkedBlockingQueue<>();
-        private boolean shouldStop = false;
+	private static class Looper implements Runnable, Closeable {
+		private final BlockingQueue<Runnable> tasks = new LinkedBlockingQueue<>();
+		private boolean shouldStop = false;
+		private Thread thread;
 
-        void submit(@NotNull Runnable task) {
-            tasks.add(task);
-        }
+		void submit(@NotNull Runnable task) {
+			tasks.add(task);
+		}
 
-        @Override
-        public void run() {
-            while (!shouldStop) {
-                try {
-                    tasks.take().run();
-                } catch (InterruptedException ex) {
-                    break;
-                }
-            }
-        }
+		@Override
+		public void run() {
+			LOGGER.trace("DealerClient.Looper started");
+			this.thread = Thread.currentThread();
+			while (!shouldStop) {
+				try {
+					tasks.take().run();
+				} catch (InterruptedException ex) {
+					break;
+				}
+			}
+			LOGGER.trace("DealerClient.Looper stopped");
+		}
 
-        @Override
-        public void close() {
-            shouldStop = true;
-        }
-    }
+		@Override
+		public void close() {
+			shouldStop = true;
+			thread.interrupt();
+		}
+	}
 
-    private class ConnectionHolder implements Closeable {
-        private final WebSocket ws;
-        private boolean closed = false;
-        private boolean receivedPong = false;
-        private ScheduledFuture<?> lastScheduledPing;
+	private class ConnectionHolder implements Closeable {
+		private final WebSocket ws;
+		private boolean closed = false;
+		private boolean receivedPong = false;
+		private ScheduledFuture<?> lastScheduledPing;
 
-        ConnectionHolder(@NotNull Session session, @NotNull Request request) {
-            ws = session.client().newWebSocket(request, new WebSocketListenerImpl());
-        }
+		ConnectionHolder(@NotNull Session session, @NotNull Request request) {
+			ws = session.client().newWebSocket(request, new WebSocketListenerImpl());
+		}
 
-        private void sendPing() {
-            ws.send("{\"type\":\"ping\"}");
-        }
+		private void sendPing() {
+			ws.send("{\"type\":\"ping\"}");
+		}
 
-        void sendReply(@NotNull String key, @NotNull RequestResult result) {
-            boolean success = result == RequestResult.SUCCESS;
-            ws.send(String.format("{\"type\":\"reply\", \"key\": \"%s\", \"payload\": {\"success\": %b}}", key, success));
-        }
+		void sendReply(@NotNull String key, @NotNull RequestResult result) {
+			boolean success = result == RequestResult.SUCCESS;
+			ws.send(String.format("{\"type\":\"reply\", \"key\": \"%s\", \"payload\": {\"success\": %b}}", key, success));
+		}
 
-        @Override
-        public void close() {
-            if (closed) {
-                ws.cancel();
-            } else {
-                closed = true;
-                ws.close(1000, null);
-            }
+		@Override
+		public void close() {
+			if (closed) {
+				ws.cancel();
+			} else {
+				closed = true;
+				ws.close(1000, null);
+			}
 
-            if (lastScheduledPing != null) {
-                lastScheduledPing.cancel(false);
-                lastScheduledPing = null;
-            }
+			if (lastScheduledPing != null) {
+				lastScheduledPing.cancel(false);
+				lastScheduledPing = null;
+			}
 
             ConnectionHolder holder = conn.get();
             if (holder == null) return;
 
             if (holder == ConnectionHolder.this)
-                connectionInvalided();
-            else
+				connectionInvalided();
+			else
                 LOGGER.debug(String.format("Did not dispatch connection invalidated: %s != %s", holder, ConnectionHolder.this));
-        }
+		}
 
-        private class WebSocketListenerImpl extends WebSocketListener {
+		private class WebSocketListenerImpl extends WebSocketListener {
 
-            @Override
-            public void onOpen(@NotNull WebSocket ws, @NotNull Response response) {
-                if (closed || scheduler.isShutdown()) {
-                    LOGGER.fatal(String.format("I wonder what happened here... Terminating. {closed: %b}", closed));
-                    return;
-                }
+			@Override
+			public void onOpen(@NotNull WebSocket ws, @NotNull Response response) {
+				if (closed || scheduler.isShutdown()) {
+					LOGGER.fatal(String.format("I wonder what happened here... Terminating. {closed: %b}", closed));
+					return;
+				}
 
-                LOGGER.debug(String.format("Dealer connected! {host: %s}", response.request().url().host()));
-                lastScheduledPing = scheduler.scheduleAtFixedRate(() -> {
-                    sendPing();
-                    receivedPong = false;
+				LOGGER.debug(String.format("Dealer connected! {host: %s}", response.request().url().host()));
+				lastScheduledPing = scheduler.scheduleAtFixedRate(() -> {
+					sendPing();
+					receivedPong = false;
 
-                    scheduler.schedule(() -> {
-                        if (lastScheduledPing == null || lastScheduledPing.isCancelled()) return;
+					scheduler.schedule(() -> {
+						if (lastScheduledPing == null || lastScheduledPing.isCancelled())
+							return;
 
-                        if (!receivedPong) {
-                            LOGGER.warn("Did not receive ping in 3 seconds. Reconnecting...");
-                            ConnectionHolder.this.close();
-                            return;
-                        }
+						if (!receivedPong) {
+							LOGGER.warn("Did not receive ping in 3 seconds. Reconnecting...");
+							ConnectionHolder.this.close();
+							return;
+						}
 
-                        receivedPong = false;
-                    }, 3, TimeUnit.SECONDS);
-                }, 0, 30, TimeUnit.SECONDS);
-            }
+						receivedPong = false;
+					}, 3, TimeUnit.SECONDS);
+				}, 0, 30, TimeUnit.SECONDS);
+			}
 
-            @Override
-            public void onMessage(@NotNull WebSocket ws, @NotNull String text) {
-                JsonObject obj = JsonParser.parseString(text).getAsJsonObject();
+			@Override
+			public void onMessage(@NotNull WebSocket ws, @NotNull String text) {
+				JsonObject obj = JsonParser.parseString(text).getAsJsonObject();
 
-                waitForListeners();
+				waitForListeners();
 
-                MessageType type = MessageType.parse(obj.get("type").getAsString());
-                switch (type) {
-                    case MESSAGE:
-                        handleMessage(obj);
-                        break;
-                    case REQUEST:
-                        handleRequest(obj);
-                        break;
-                    case PONG:
-                        receivedPong = true;
-                        break;
-                    case PING:
-                        break;
-                    default:
-                        throw new IllegalArgumentException("Unknown message type for " + type);
-                }
-            }
+				MessageType type = MessageType.parse(obj.get("type").getAsString());
+				switch (type) {
+					case MESSAGE:
+						handleMessage(obj);
+						break;
+					case REQUEST:
+						handleRequest(obj);
+						break;
+					case PONG:
+						receivedPong = true;
+						break;
+					case PING:
+						break;
+					default:
+						throw new IllegalArgumentException("Unknown message type for " + type);
+				}
+			}
 
-            @Override
-            public void onFailure(@NotNull WebSocket ws, @NotNull Throwable t, @Nullable Response response) {
-                LOGGER.warn("An exception occurred. Reconnecting...", t);
-                ConnectionHolder.this.close();
-            }
-        }
-    }
+			@Override
+			public void onFailure(@NotNull WebSocket ws, @NotNull Throwable t, @Nullable Response response) {
+				LOGGER.warn("An exception occurred. Reconnecting...", t);
+				ConnectionHolder.this.close();
+			}
+		}
+	}
 }

--- a/core/src/main/java/xyz/gianlu/librespot/player/PlayerRunner.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/PlayerRunner.java
@@ -148,6 +148,8 @@ public class PlayerRunner implements Runnable, Closeable {
 
     @Override
     public void run() {
+        LOGGER.trace("PlayerRunner started");
+
         byte[] buffer = new byte[Codec.BUFFER_SIZE * 2];
 
         boolean started = false;
@@ -183,6 +185,8 @@ public class PlayerRunner implements Runnable, Closeable {
             output.close();
         } catch (IOException ignored) {
         }
+
+        LOGGER.trace("PlayerRunner stopped");
     }
 
     @Override
@@ -414,10 +418,13 @@ public class PlayerRunner implements Runnable, Closeable {
 
         @Override
         public void run() {
+            LOGGER.debug("~~~PlayerRunner.Looper started!");
             try {
-                while (true) {
+                boolean shouldBreak = false;
+                while (!shouldBreak) {
                     CommandBundle cmd = commands.take();
                     TrackHandler handler;
+
                     switch (cmd.cmd) {
                         case Load:
                             handler = (TrackHandler) cmd.args[0];
@@ -506,7 +513,8 @@ public class PlayerRunner implements Runnable, Closeable {
                             }
                             break;
                         case TerminateMixer:
-                            return;
+                            shouldBreak = true;
+                            break;
                         default:
                             throw new IllegalArgumentException("Unknown command: " + cmd.cmd);
                     }
@@ -514,6 +522,7 @@ public class PlayerRunner implements Runnable, Closeable {
             } catch (InterruptedException ex) {
                 LOGGER.fatal("Failed handling command!", ex);
             }
+            LOGGER.debug("~~~PlayerRunner.Looper stopped!");
         }
     }
 
@@ -749,6 +758,8 @@ public class PlayerRunner implements Runnable, Closeable {
 
         @Override
         public void run() {
+            LOGGER.trace("TrackHandler started");
+
             waitReady();
 
             int seekTo = -1;
@@ -792,6 +803,8 @@ public class PlayerRunner implements Runnable, Closeable {
             }
 
             close();
+
+            LOGGER.trace("TrackHandler stopped");
         }
 
         boolean isInMixer() {

--- a/core/src/main/java/xyz/gianlu/librespot/player/PlayerRunner.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/PlayerRunner.java
@@ -418,7 +418,7 @@ public class PlayerRunner implements Runnable, Closeable {
 
         @Override
         public void run() {
-            LOGGER.debug("PlayerRunner.Looper started");
+            LOGGER.trace("PlayerRunner.Looper started");
             try {
                 boolean shouldBreak = false;
                 while (!shouldBreak) {
@@ -522,7 +522,7 @@ public class PlayerRunner implements Runnable, Closeable {
             } catch (InterruptedException ex) {
                 LOGGER.fatal("Failed handling command!", ex);
             }
-            LOGGER.debug("PlayerRunner.Looper stopped");
+            LOGGER.trace("PlayerRunner.Looper stopped");
         }
     }
 

--- a/core/src/main/java/xyz/gianlu/librespot/player/PlayerRunner.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/PlayerRunner.java
@@ -148,8 +148,6 @@ public class PlayerRunner implements Runnable, Closeable {
 
     @Override
     public void run() {
-        LOGGER.trace("PlayerRunner started");
-
         byte[] buffer = new byte[Codec.BUFFER_SIZE * 2];
 
         boolean started = false;
@@ -185,8 +183,6 @@ public class PlayerRunner implements Runnable, Closeable {
             output.close();
         } catch (IOException ignored) {
         }
-
-        LOGGER.trace("PlayerRunner stopped");
     }
 
     @Override
@@ -418,13 +414,10 @@ public class PlayerRunner implements Runnable, Closeable {
 
         @Override
         public void run() {
-            LOGGER.trace("PlayerRunner.Looper started");
             try {
-                boolean shouldBreak = false;
-                while (!shouldBreak) {
+                while (true) {
                     CommandBundle cmd = commands.take();
                     TrackHandler handler;
-
                     switch (cmd.cmd) {
                         case Load:
                             handler = (TrackHandler) cmd.args[0];
@@ -513,8 +506,7 @@ public class PlayerRunner implements Runnable, Closeable {
                             }
                             break;
                         case TerminateMixer:
-                            shouldBreak = true;
-                            break;
+                            return;
                         default:
                             throw new IllegalArgumentException("Unknown command: " + cmd.cmd);
                     }
@@ -522,7 +514,6 @@ public class PlayerRunner implements Runnable, Closeable {
             } catch (InterruptedException ex) {
                 LOGGER.fatal("Failed handling command!", ex);
             }
-            LOGGER.trace("PlayerRunner.Looper stopped");
         }
     }
 
@@ -758,8 +749,6 @@ public class PlayerRunner implements Runnable, Closeable {
 
         @Override
         public void run() {
-            LOGGER.trace("TrackHandler started");
-
             waitReady();
 
             int seekTo = -1;
@@ -803,8 +792,6 @@ public class PlayerRunner implements Runnable, Closeable {
             }
 
             close();
-
-            LOGGER.trace("TrackHandler stopped");
         }
 
         boolean isInMixer() {

--- a/core/src/main/java/xyz/gianlu/librespot/player/PlayerRunner.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/PlayerRunner.java
@@ -418,7 +418,7 @@ public class PlayerRunner implements Runnable, Closeable {
 
         @Override
         public void run() {
-            LOGGER.debug("~~~PlayerRunner.Looper started!");
+            LOGGER.debug("PlayerRunner.Looper started");
             try {
                 boolean shouldBreak = false;
                 while (!shouldBreak) {
@@ -522,7 +522,7 @@ public class PlayerRunner implements Runnable, Closeable {
             } catch (InterruptedException ex) {
                 LOGGER.fatal("Failed handling command!", ex);
             }
-            LOGGER.debug("~~~PlayerRunner.Looper stopped!");
+            LOGGER.debug("PlayerRunner.Looper stopped");
         }
     }
 

--- a/core/src/main/java/xyz/gianlu/librespot/player/PlayerRunner.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/PlayerRunner.java
@@ -148,6 +148,8 @@ public class PlayerRunner implements Runnable, Closeable {
 
     @Override
     public void run() {
+        LOGGER.trace("PlayerRunner started");
+
         byte[] buffer = new byte[Codec.BUFFER_SIZE * 2];
 
         boolean started = false;
@@ -183,6 +185,8 @@ public class PlayerRunner implements Runnable, Closeable {
             output.close();
         } catch (IOException ignored) {
         }
+
+        LOGGER.trace("PlayerRunner stopped");
     }
 
     @Override
@@ -414,8 +418,10 @@ public class PlayerRunner implements Runnable, Closeable {
 
         @Override
         public void run() {
+            LOGGER.trace("PlayerRunner.Looper started");
             try {
-                while (true) {
+                boolean shouldBreak = false;
+                while (!shouldBreak) {
                     CommandBundle cmd = commands.take();
                     TrackHandler handler;
                     switch (cmd.cmd) {
@@ -506,7 +512,8 @@ public class PlayerRunner implements Runnable, Closeable {
                             }
                             break;
                         case TerminateMixer:
-                            return;
+                            shouldBreak = true;
+                            break;
                         default:
                             throw new IllegalArgumentException("Unknown command: " + cmd.cmd);
                     }
@@ -514,6 +521,7 @@ public class PlayerRunner implements Runnable, Closeable {
             } catch (InterruptedException ex) {
                 LOGGER.fatal("Failed handling command!", ex);
             }
+            LOGGER.trace("PlayerRunner.Looper stopped");
         }
     }
 
@@ -749,6 +757,8 @@ public class PlayerRunner implements Runnable, Closeable {
 
         @Override
         public void run() {
+            LOGGER.trace("TrackHandler started");
+
             waitReady();
 
             int seekTo = -1;
@@ -792,6 +802,8 @@ public class PlayerRunner implements Runnable, Closeable {
             }
 
             close();
+
+            LOGGER.trace("TrackHandler stopped");
         }
 
         boolean isInMixer() {

--- a/core/src/main/java/xyz/gianlu/librespot/player/feeders/storage/ChannelManager.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/feeders/storage/ChannelManager.java
@@ -160,6 +160,7 @@ public class ChannelManager extends PacketsManager {
 
             @Override
             public void run() {
+                LOGGER.trace("ChannelManager.Handler started");
                 while (true) {
                     try {
                         if (handle(queue.take())) {
@@ -170,6 +171,7 @@ public class ChannelManager extends PacketsManager {
                         LOGGER.fatal("Failed handling packet!", ex);
                     }
                 }
+                LOGGER.trace("ChannelManager.Handler stopped");
             }
         }
     }

--- a/core/src/main/java/xyz/gianlu/librespot/player/feeders/storage/ChannelManager.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/feeders/storage/ChannelManager.java
@@ -59,7 +59,7 @@ public class ChannelManager extends PacketsManager {
 
     @Override
     protected void handle(@NotNull Packet packet) {
-        throw new UnsupportedOperationException();
+       throw new UnsupportedOperationException();
     }
 
     @Override
@@ -160,7 +160,6 @@ public class ChannelManager extends PacketsManager {
 
             @Override
             public void run() {
-                LOGGER.trace("ChannelManager.Handler started");
                 while (true) {
                     try {
                         if (handle(queue.take())) {
@@ -171,7 +170,6 @@ public class ChannelManager extends PacketsManager {
                         LOGGER.fatal("Failed handling packet!", ex);
                     }
                 }
-                LOGGER.trace("ChannelManager.Handler stopped");
             }
         }
     }

--- a/core/src/main/java/xyz/gianlu/librespot/player/feeders/storage/ChannelManager.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/feeders/storage/ChannelManager.java
@@ -59,7 +59,7 @@ public class ChannelManager extends PacketsManager {
 
     @Override
     protected void handle(@NotNull Packet packet) {
-       throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
(Once again..)
Right now, threads are not correctly stopped once the session is closed.
Your Runables often implement "Closeable" (I have never used Runnables that implement Closeable before?) but you are not using them inside try-with-resource which makes manual call of .close() required and additionally the threads have to be interrupted in some situations.

I added some logging at trace-level and in my situation it seems to work correct now.
Maybe this also solve the issue with accidental reconnect after Session.close has been called while the network is interrupted.
