### PR TITLE
Close Threads/Executors on Session.close()

### DIFF
--- a/common/src/main/java/xyz/gianlu/librespot/common/AsyncWorker.java
+++ b/common/src/main/java/xyz/gianlu/librespot/common/AsyncWorker.java
@@ -37,6 +37,8 @@ public class AsyncWorker<T> implements Closeable, Runnable {
 
     @Override
     public void run() {
+        LOGGER.trace(String.format("AsyncWorker{%s} is starting", name));
+
         while (running) {
             try {
                 T polled = internalQueue.take();

--- a/core/src/main/java/xyz/gianlu/librespot/core/PacketsManager.java
+++ b/core/src/main/java/xyz/gianlu/librespot/core/PacketsManager.java
@@ -4,13 +4,14 @@ import org.jetbrains.annotations.NotNull;
 import xyz.gianlu.librespot.common.AsyncWorker;
 import xyz.gianlu.librespot.crypto.Packet;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 
 /**
  * @author Gianlu
  */
-public abstract class PacketsManager implements AutoCloseable {
+public abstract class PacketsManager implements Closeable {
     protected final Session session;
     private final ExecutorService executorService;
     private final AsyncWorker<Packet> asyncWorker;

--- a/core/src/main/java/xyz/gianlu/librespot/core/ZeroconfServer.java
+++ b/core/src/main/java/xyz/gianlu/librespot/core/ZeroconfServer.java
@@ -475,6 +475,7 @@ public class ZeroconfServer implements Closeable {
         public void close() throws IOException {
             shouldStop = true;
             serverSocket.close();
+            executorService.shutdown();
         }
     }
 }

--- a/core/src/main/java/xyz/gianlu/librespot/dealer/DealerClient.java
+++ b/core/src/main/java/xyz/gianlu/librespot/dealer/DealerClient.java
@@ -209,7 +209,6 @@ public class DealerClient implements Closeable {
 
     @Override
     public void close() {
-
         asyncWorker.close();
         scheduler.shutdown();
 

--- a/core/src/main/java/xyz/gianlu/librespot/dealer/DealerClient.java
+++ b/core/src/main/java/xyz/gianlu/librespot/dealer/DealerClient.java
@@ -209,6 +209,10 @@ public class DealerClient implements Closeable {
 
     @Override
     public void close() {
+
+        asyncWorker.close();
+        scheduler.shutdown();
+
         if (conn != null) {
             ConnectionHolder tmp = conn; // Do not trigger connectionInvalided()
             conn = null;
@@ -220,8 +224,6 @@ public class DealerClient implements Closeable {
             lastScheduledReconnection = null;
         }
 
-        asyncWorker.close();
-        scheduler.shutdown();
         msgListeners.clear();
     }
 

--- a/core/src/main/java/xyz/gianlu/librespot/player/Player.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/Player.java
@@ -646,6 +646,10 @@ public class Player implements Closeable, DeviceStateHandler.Listener, PlayerRun
 
         runner.close();
         if (state != null) state.removeListener(this);
+
+        scheduler.shutdown();
+
+        events.close();
     }
 
     @Nullable
@@ -982,6 +986,10 @@ public class Player implements Closeable, DeviceStateHandler.Listener, PlayerRun
         void inactiveSession(boolean timeout) {
             for (EventsListener l : new ArrayList<>(listeners))
                 executorService.execute(() -> l.onInactiveSession(timeout));
+        }
+
+        public void close() {
+            executorService.shutdown();
         }
     }
 }

--- a/core/src/main/java/xyz/gianlu/librespot/player/Player.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/Player.java
@@ -648,7 +648,6 @@ public class Player implements Closeable, DeviceStateHandler.Listener, PlayerRun
         if (state != null) state.removeListener(this);
 
         scheduler.shutdown();
-
         events.close();
     }
 

--- a/core/src/main/java/xyz/gianlu/librespot/player/PlayerRunner.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/PlayerRunner.java
@@ -150,6 +150,8 @@ public class PlayerRunner implements Runnable, Closeable {
 
     @Override
     public void run() {
+        LOGGER.trace("PlayerRunner is starting");
+
         byte[] buffer = new byte[Codec.BUFFER_SIZE * 2];
 
         boolean started = false;
@@ -185,6 +187,8 @@ public class PlayerRunner implements Runnable, Closeable {
             output.close();
         } catch (IOException ignored) {
         }
+
+        LOGGER.trace("PlayerRunner is shutting down");
     }
 
     @Override
@@ -746,6 +750,8 @@ public class PlayerRunner implements Runnable, Closeable {
 
         @Override
         public void run() {
+            LOGGER.trace("PlayerRunner.TrackHandler is starting");
+
             waitReady();
 
             int seekTo = -1;
@@ -789,6 +795,8 @@ public class PlayerRunner implements Runnable, Closeable {
             }
 
             close();
+
+            LOGGER.trace("PlayerRunner.TrackHandler is shutting down");
         }
 
         boolean isInMixer() {

--- a/core/src/main/java/xyz/gianlu/librespot/player/feeders/storage/ChannelManager.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/feeders/storage/ChannelManager.java
@@ -169,8 +169,6 @@ public class ChannelManager extends PacketsManager {
                 LOGGER.trace("ChannelManager.Handler is starting");
 
                 while (true) {
-                    // TODO Check if loop breaks at Session.close()
-
                     try {
                         if (handle(queue.take())) {
                             channels.remove(id);

--- a/core/src/main/java/xyz/gianlu/librespot/player/feeders/storage/ChannelManager.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/feeders/storage/ChannelManager.java
@@ -93,6 +93,12 @@ public class ChannelManager extends PacketsManager {
         LOGGER.fatal("Failed handling packet!", ex);
     }
 
+    @Override
+    public void close() {
+        executorService.shutdown();
+        super.close();
+    }
+
     public class Channel {
         public final short id;
         private final BlockingQueue<ByteBuffer> queue = new LinkedBlockingQueue<>();
@@ -161,18 +167,22 @@ public class ChannelManager extends PacketsManager {
             @Override
             public void run() {
                 LOGGER.trace("ChannelManager.Handler is starting");
+
                 while (true) {
                     // TODO Check if loop breaks at Session.close()
-					// TODO ExecutorService should be shutdown on Session.close() to avoid zombie threads
+
                     try {
                         if (handle(queue.take())) {
                             channels.remove(id);
                             break;
                         }
-                    } catch (InterruptedException | IOException ex) {
+                    } catch (IOException ex) {
                         LOGGER.fatal("Failed handling packet!", ex);
+                    } catch (InterruptedException ex) {
+                        break;
                     }
                 }
+
                 LOGGER.trace("ChannelManager.Handler is shutting down");
             }
         }

--- a/core/src/main/java/xyz/gianlu/librespot/player/feeders/storage/ChannelManager.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/feeders/storage/ChannelManager.java
@@ -160,7 +160,10 @@ public class ChannelManager extends PacketsManager {
 
             @Override
             public void run() {
+                LOGGER.trace("ChannelManager.Handler is starting");
                 while (true) {
+                    // TODO Check if loop breaks at Session.close()
+					// TODO ExecutorService should be shutdown on Session.close() to avoid zombie threads
                     try {
                         if (handle(queue.take())) {
                             channels.remove(id);
@@ -170,6 +173,7 @@ public class ChannelManager extends PacketsManager {
                         LOGGER.fatal("Failed handling packet!", ex);
                     }
                 }
+                LOGGER.trace("ChannelManager.Handler is shutting down");
             }
         }
     }


### PR DESCRIPTION
There are several points where Threads & Executors are not stopped/shutdown once Session.close() is called. This may leave zombie-threads & ongoing threads running if you use librespot-java inside an application.

I was not able to trigger the ChannelManager-methods in any way. Is this dead code or when is the ChannelManager accessed?