### PR TITLE
Do not get a Cipher instance every time we decrypt an AES chunk

### DIFF
--- a/core/src/main/java/xyz/gianlu/librespot/player/decrypt/AesAudioDecrypt.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/decrypt/AesAudioDecrypt.java
@@ -3,11 +3,13 @@ package xyz.gianlu.librespot.player.decrypt;
 import xyz.gianlu.librespot.common.Utils;
 
 import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
 
 import static xyz.gianlu.librespot.player.feeders.storage.ChannelManager.CHUNK_SIZE;
 
@@ -18,16 +20,21 @@ public final class AesAudioDecrypt implements AudioDecrypt {
     private static final byte[] AUDIO_AES_IV = new byte[]{(byte) 0x72, (byte) 0xe0, (byte) 0x67, (byte) 0xfb, (byte) 0xdd, (byte) 0xcb, (byte) 0xcf, (byte) 0x77, (byte) 0xeb, (byte) 0xe8, (byte) 0xbc, (byte) 0x64, (byte) 0x3f, (byte) 0x63, (byte) 0x0d, (byte) 0x93};
     private final static BigInteger IV_INT = new BigInteger(1, AUDIO_AES_IV);
     private final SecretKeySpec secretKeySpec;
+    private final Cipher cipher;
 
     public AesAudioDecrypt(byte[] key) {
         this.secretKeySpec = new SecretKeySpec(key, "AES");
+        try {
+            this.cipher = Cipher.getInstance("AES/CTR/NoPadding");
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+            throw new IllegalStateException(); // This should never happen
+        }
     }
 
     public synchronized void decryptChunk(int chunkIndex, byte[] in, byte[] out) throws IOException {
         int pos = CHUNK_SIZE * chunkIndex;
 
         try {
-            Cipher cipher = Cipher.getInstance("AES/CTR/NoPadding");
             cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, new IvParameterSpec(Utils.toByteArray(IV_INT.add(BigInteger.valueOf(pos / 16)))));
 
             for (int i = 0; i < in.length; i += 4096) {


### PR DESCRIPTION
Since we're calling cipher.init() in every call, there's no need to get the instance every time. Just save it as a private final variable.
In case it ever throws an exception during decoding, running ciper.init() again will bring it to a correct state again (according to the documentation).

This might save us a few ms during playback :)