### PR TITLE
Facebook authentication correction

### DIFF
--- a/core/src/main/java/xyz/gianlu/librespot/core/FacebookAuthenticator.java
+++ b/core/src/main/java/xyz/gianlu/librespot/core/FacebookAuthenticator.java
@@ -80,7 +80,7 @@ public class FacebookAuthenticator implements Closeable {
 
         JsonObject data = obj.getAsJsonObject("credentials");
         credentials = Authentication.LoginCredentials.newBuilder()
-                .setUsername(data.get("authUsername").getAsString())
+                .setUsername(data.get("username").getAsString())
                 .setTyp(Authentication.AuthenticationType.forNumber(data.get("auth_type").getAsInt()))
                 .setAuthData(ByteString.copyFrom(Base64.getDecoder().decode(data.get("encoded_auth_blob").getAsString())))
                 .build();


### PR DESCRIPTION
The credentials json object has no authUsername property, instead it has a username property.