### PR TITLE
Prevent blocking and IllegalArgumentException while closing session

### DIFF
--- a/core/src/main/java/xyz/gianlu/librespot/player/Player.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/Player.java
@@ -736,8 +736,10 @@ public class Player implements Closeable, DeviceStateHandler.Listener, PlayerSes
 
     @Override
     public void close() {
-        if (playerSession != null)
+        if (playerSession != null) {
             endMetrics(playerSession.currentPlaybackId(), PlaybackMetrics.Reason.LOGOUT, playerSession.currentMetrics(), state.getPosition());
+            playerSession.close();
+        }
 
         state.close();
         events.listeners.clear();


### PR DESCRIPTION
In case you lose the network-connection during active playback and call Session.close(), the running threads may block because they wait for a re-connection.
Additionally, an IllegalArgumentException could have been thrown because a playerSession.close(); was missing.