### PR TITLE
Start line before first write to line

### DIFF
--- a/core/src/main/java/xyz/gianlu/librespot/player/mixing/AudioSink.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/mixing/AudioSink.java
@@ -144,10 +144,10 @@ public final class AudioSink implements Runnable, Closeable {
                     }
                 }
             } else {
-                if (!started)
-                    started = output.start();
-
                 try {
+                    if (!started)
+                        started = output.start();
+
                     int count = mixing.read(buffer);
                     output.write(buffer, count);
                 } catch (IOException | LineUnavailableException | LineHelper.MixerException ex) {
@@ -214,8 +214,9 @@ public final class AudioSink implements Runnable, Closeable {
             if (line != null) line.stop();
         }
 
-        boolean start() {
-            if (line != null) {
+        boolean start() throws LineUnavailableException {
+            if (type == Type.MIXER) {
+                acquireLine();
                 line.start();
                 return true;
             }
@@ -225,7 +226,6 @@ public final class AudioSink implements Runnable, Closeable {
 
         void write(byte[] buffer, int len) throws IOException, LineUnavailableException, LineHelper.MixerException {
             if (type == Type.MIXER) {
-                acquireLine();
                 line.write(buffer, 0, len);
             } else if (type == Type.PIPE) {
                 if (out == null) {


### PR DESCRIPTION
Right now, inside the AudioSink, line.start() is called _after_ the first write() to the line.
Depending on the line this may either case errors or the very first audio-package gets lost.

With this PR, the line is acquired and started before the first write, instead before the second write.