### PR TITLE
Add EventsListener.onPanicState()

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -37,19 +37,20 @@ All the endpoints will respond with `200` if successful or:
 ### Events
 You can subscribe for players events by creating a WebSocket connection to `/events`.
 The currently available events are:
-- `contextChanged`, the Spotify context URI changed
-- `trackChanged`, the Spotify track URI changed
-- `playbackPaused`, playback has been paused
-- `playbackResumed`, playback has been resumed
-- `volumeChanged`, playback volume changed
-- `trackSeeked`, track has been seeked
-- `metadataAvailable`, metadata for the current track is available
-- `playbackHaltStateChanged`, playback halted or resumed from halt
-- `sessionCleared`, (Zeroconf only) current session went away
-- `sessionChanged`, (Zeroconf only) current session changed
-- `inactiveSession`, current session is now inactive (no audio)
-- `connectionDropped`, a network error occurred and we're trying to reconnect
-- `connectionEstablished`, successfully reconnected
+- `contextChanged` The Spotify context URI changed
+- `trackChanged` The Spotify track URI changed
+- `playbackPaused` Playback has been paused
+- `playbackResumed` Playback has been resumed
+- `volumeChanged` Playback volume changed
+- `trackSeeked` Track has been seeked
+- `metadataAvailable` Metadata for the current track is available
+- `playbackHaltStateChanged` Playback halted or resumed from halt
+- `sessionCleared` Current session went away (Zeroconf only)
+- `sessionChanged` Current session changed (Zeroconf only)
+- `inactiveSession` Current session is now inactive (no audio)
+- `connectionDropped` A network error occurred and we're trying to reconnect
+- `connectionEstablished` Successfully reconnected
+- `panic` Entered the panic state, playback is stopped. This is usually recoverable.
 
 ## Examples
 `curl -X POST -d "uri=spotify:track:xxxxxxxxxxxxxxxxxxxxxx&play=true" http://localhost:24879/player/load`

--- a/api/src/main/java/xyz/gianlu/librespot/api/handlers/EventsHandler.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/handlers/EventsHandler.java
@@ -12,7 +12,6 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
 import xyz.gianlu.librespot.api.SessionWrapper;
 import xyz.gianlu.librespot.common.ProtobufToJson;
-import xyz.gianlu.librespot.core.EventService;
 import xyz.gianlu.librespot.core.Session;
 import xyz.gianlu.librespot.mercury.model.PlayableId;
 import xyz.gianlu.librespot.player.Player;
@@ -110,8 +109,10 @@ public final class EventsHandler extends WebSocketProtocolHandshakeHandler imple
     }
 
     @Override
-    public void onPanicState(EventService.PlaybackMetrics.@Nullable Reason reason) {
-
+    public void onPanicState() {
+        JsonObject obj = new JsonObject();
+        obj.addProperty("event", "panic");
+        dispatch(obj);
     }
 
     @Override

--- a/api/src/main/java/xyz/gianlu/librespot/api/handlers/EventsHandler.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/handlers/EventsHandler.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
 import xyz.gianlu.librespot.api.SessionWrapper;
 import xyz.gianlu.librespot.common.ProtobufToJson;
+import xyz.gianlu.librespot.core.EventService;
 import xyz.gianlu.librespot.core.Session;
 import xyz.gianlu.librespot.mercury.model.PlayableId;
 import xyz.gianlu.librespot.player.Player;
@@ -106,6 +107,11 @@ public final class EventsHandler extends WebSocketProtocolHandshakeHandler imple
         obj.addProperty("event", "volumeChanged");
         obj.addProperty("value", volume);
         dispatch(obj);
+    }
+
+    @Override
+    public void onPanicState(EventService.PlaybackMetrics.@Nullable Reason reason) {
+
     }
 
     @Override

--- a/core/src/main/java/xyz/gianlu/librespot/player/Player.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/Player.java
@@ -172,7 +172,7 @@ public class Player implements Closeable, DeviceStateHandler.Listener, PlayerSes
             endMetrics(playerSession.currentPlaybackId(), reason, playerSession.currentMetrics(), state.getPosition());
         }
 
-        events.panicState(reason);
+        events.panicState();
     }
 
     /**
@@ -819,7 +819,7 @@ public class Player implements Closeable, DeviceStateHandler.Listener, PlayerSes
 
         void onVolumeChanged(@Range(from = 0, to = 1) float volume);
 
-        void onPanicState(@Nullable PlaybackMetrics.Reason reason);
+        void onPanicState();
     }
 
     /**
@@ -1083,9 +1083,9 @@ public class Player implements Closeable, DeviceStateHandler.Listener, PlayerSes
         }
 
 
-        private void panicState(@Nullable PlaybackMetrics.Reason reason) {
+        private void panicState() {
             for (EventsListener l : new ArrayList<>(listeners))
-                executorService.execute(() -> l.onPanicState(reason));
+                executorService.execute(l::onPanicState);
         }
 
         public void close() {

--- a/core/src/main/java/xyz/gianlu/librespot/player/Player.java
+++ b/core/src/main/java/xyz/gianlu/librespot/player/Player.java
@@ -171,6 +171,8 @@ public class Player implements Closeable, DeviceStateHandler.Listener, PlayerSes
         } else if (playerSession != null) {
             endMetrics(playerSession.currentPlaybackId(), reason, playerSession.currentMetrics(), state.getPosition());
         }
+
+        events.panicState(reason);
     }
 
     /**
@@ -816,6 +818,8 @@ public class Player implements Closeable, DeviceStateHandler.Listener, PlayerSes
         void onInactiveSession(boolean timeout);
 
         void onVolumeChanged(@Range(from = 0, to = 1) float volume);
+
+        void onPanicState(@Nullable PlaybackMetrics.Reason reason);
     }
 
     /**
@@ -1076,6 +1080,12 @@ public class Player implements Closeable, DeviceStateHandler.Listener, PlayerSes
         void inactiveSession(boolean timeout) {
             for (EventsListener l : new ArrayList<>(listeners))
                 executorService.execute(() -> l.onInactiveSession(timeout));
+        }
+
+
+        private void panicState(@Nullable PlaybackMetrics.Reason reason) {
+            for (EventsListener l : new ArrayList<>(listeners))
+                executorService.execute(() -> l.onPanicState(reason));
         }
 
         public void close() {


### PR DESCRIPTION
Right now it's almost impossible to know if anything goes wrong while playback without checking the logs.
This PR adds an EventsListener.onPanicState().

Maybe you may also publish the information inside the EventsHandler?