### PR TITLE
Add Profile Endpoint to API

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -34,6 +34,10 @@ All the endpoints will respond with `200` if successful or:
 ### Tokens
 - `POST /token/{scope}` Request an access token for a specific scope (or a comma separated list of scopes).
 
+### Profile
+- `GET /profile/{user_id}/followers` Retrieve a list of profiles that are followers of the specified user
+- `GET /profile/{user_id}/following` Retrieve a list of profiles that the specified user is following
+
 ### Events
 You can subscribe for players events by creating a WebSocket connection to `/events`.
 The currently available events are:

--- a/api/src/main/java/xyz/gianlu/librespot/api/ApiServer.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/ApiServer.java
@@ -28,6 +28,7 @@ public class ApiServer {
                 .post("/metadata/{uri}", new MetadataHandler(wrapper, false))
                 .post("/search/{query}", new SearchHandler(wrapper))
                 .post("/token/{scope}", new TokensHandler(wrapper))
+                .get("/profile/{user_id}/{action}", new ProfileHandler(wrapper))
                 .get("/events", events));
     }
 

--- a/api/src/main/java/xyz/gianlu/librespot/api/ApiServer.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/ApiServer.java
@@ -28,7 +28,7 @@ public class ApiServer {
                 .post("/metadata/{uri}", new MetadataHandler(wrapper, false))
                 .post("/search/{query}", new SearchHandler(wrapper))
                 .post("/token/{scope}", new TokensHandler(wrapper))
-                .get("/profile/{user_id}/{action}", new ProfileHandler(wrapper))
+                .post("/profile/{user_id}/{action}", new ProfileHandler(wrapper))
                 .get("/events", events));
     }
 

--- a/api/src/main/java/xyz/gianlu/librespot/api/handlers/ProfileHandler.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/handlers/ProfileHandler.java
@@ -1,0 +1,55 @@
+package xyz.gianlu.librespot.api.handlers;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+import io.undertow.util.PathTemplateMatch;
+import org.jetbrains.annotations.NotNull;
+import xyz.gianlu.librespot.api.SessionWrapper;
+import xyz.gianlu.librespot.api.Utils;
+import xyz.gianlu.librespot.core.Session;
+import xyz.gianlu.librespot.mercury.MercuryClient;
+import xyz.gianlu.librespot.mercury.MercuryRequests;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class ProfileHandler extends AbsSessionHandler {
+
+    public ProfileHandler(@NotNull SessionWrapper wrapper) {
+        super(wrapper);
+    }
+
+    private static void profileAction(@NotNull HttpServerExchange exchange, @NotNull Session session, String suffix) throws IOException {
+        String uri = "hm://user-profile-view/v2/desktop/profile/" + suffix;
+        try {
+            MercuryRequests.GeneralJson resp = session.mercury().sendSync(MercuryRequests.generalJsonGet(uri));
+            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
+            exchange.getResponseSender().send(resp.toString());
+        } catch (MercuryClient.MercuryException e) {
+            exchange.setStatusCode(e.statusCode);
+            exchange.getResponseSender().send("Upstream Error: " + e.statusCode);
+        }
+    }
+
+    @Override
+    protected void handleRequest(@NotNull HttpServerExchange exchange, @NotNull Session session) throws Exception {
+        exchange.startBlocking();
+        if (exchange.isInIoThread()) {
+            exchange.dispatch(this);
+            return;
+        }
+
+        Map<String, String> params = exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
+        String user_id = params.get("user_id");
+        String action = params.get("action");
+
+        switch (action) {
+            case "followers":
+            case "following":
+                profileAction(exchange, session, user_id + "/" + action);
+                break;
+            default:
+                Utils.invalidParameter(exchange, "action");
+        }
+    }
+}

--- a/core/src/main/java/xyz/gianlu/librespot/core/TokenProvider.java
+++ b/core/src/main/java/xyz/gianlu/librespot/core/TokenProvider.java
@@ -1,6 +1,7 @@
 package xyz.gianlu.librespot.core;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -48,8 +49,8 @@ public final class TokenProvider {
         }
 
         LOGGER.debug("Token expired or not suitable, requesting again. {scopes: {}, oldToken: {}}", Arrays.asList(scopes), token);
-        MercuryRequests.KeymasterToken resp = session.mercury().sendSync(MercuryRequests.requestToken(session.deviceId(), String.join(",", scopes)));
-        token = new StoredToken(resp);
+        MercuryRequests.GenericJson resp = session.mercury().sendSync(MercuryRequests.requestToken(session.deviceId(), String.join(",", scopes)));
+        token = new StoredToken(resp.obj);
 
         LOGGER.debug("Updated token successfully! {scopes: {}, newToken: {}}", Arrays.asList(scopes), token);
         tokens.add(token);
@@ -68,12 +69,12 @@ public final class TokenProvider {
         public final String[] scopes;
         public final long timestamp;
 
-        private StoredToken(@NotNull MercuryRequests.KeymasterToken token) {
+        private StoredToken(@NotNull JsonObject obj) {
             timestamp = TimeProvider.currentTimeMillis();
-            expiresIn = token.obj.get("expiresIn").getAsInt();
-            accessToken = token.obj.get("accessToken").getAsString();
+            expiresIn = obj.get("expiresIn").getAsInt();
+            accessToken = obj.get("accessToken").getAsString();
 
-            JsonArray scopesArray = token.obj.getAsJsonArray("scope");
+            JsonArray scopesArray = obj.getAsJsonArray("scope");
             scopes = new String[scopesArray.size()];
             for (int i = 0; i < scopesArray.size(); i++)
                 scopes[i] = scopesArray.get(i).getAsString();

--- a/core/src/main/java/xyz/gianlu/librespot/mercury/MercuryClient.java
+++ b/core/src/main/java/xyz/gianlu/librespot/mercury/MercuryClient.java
@@ -352,8 +352,11 @@ public final class MercuryClient extends PacketsManager {
     }
 
     public static class MercuryException extends Exception {
+        public final int statusCode;
+
         private MercuryException(Response response) {
             super(String.format("status: %d", response.statusCode));
+            this.statusCode = response.statusCode;
         }
     }
 

--- a/core/src/main/java/xyz/gianlu/librespot/mercury/MercuryClient.java
+++ b/core/src/main/java/xyz/gianlu/librespot/mercury/MercuryClient.java
@@ -352,11 +352,8 @@ public final class MercuryClient extends PacketsManager {
     }
 
     public static class MercuryException extends Exception {
-        public final int statusCode;
-
-        private MercuryException(Response response) {
+        private MercuryException(@NotNull Response response) {
             super(String.format("status: %d", response.statusCode));
-            this.statusCode = response.statusCode;
         }
     }
 

--- a/core/src/main/java/xyz/gianlu/librespot/mercury/MercuryRequests.java
+++ b/core/src/main/java/xyz/gianlu/librespot/mercury/MercuryRequests.java
@@ -98,13 +98,13 @@ public final class MercuryRequests {
     }
 
     @NotNull
-    public static JsonMercuryRequest<KeymasterToken> requestToken(@NotNull String deviceId, @NotNull String scope) {
-        return new JsonMercuryRequest<>(RawMercuryRequest.get(String.format("hm://keymaster/token/authenticated?scope=%s&client_id=%s&device_id=%s", scope, KEYMASTER_CLIENT_ID, deviceId)), KeymasterToken.class);
+    public static JsonMercuryRequest<GenericJson> requestToken(@NotNull String deviceId, @NotNull String scope) {
+        return new JsonMercuryRequest<>(RawMercuryRequest.get(String.format("hm://keymaster/token/authenticated?scope=%s&client_id=%s&device_id=%s", scope, KEYMASTER_CLIENT_ID, deviceId)), GenericJson.class);
     }
 
     @NotNull
-    public static JsonMercuryRequest<GeneralJson> generalJsonGet(@NotNull String uri) {
-        return new JsonMercuryRequest<>(RawMercuryRequest.get(uri), GeneralJson.class);
+    public static JsonMercuryRequest<GenericJson> getGenericJson(@NotNull String uri) {
+        return new JsonMercuryRequest<>(RawMercuryRequest.get(uri), GenericJson.class);
     }
 
     @NotNull
@@ -165,9 +165,9 @@ public final class MercuryRequests {
         }
     }
 
-    public static final class GeneralJson extends JsonWrapper {
+    public static final class GenericJson extends JsonWrapper {
 
-        public GeneralJson(@NotNull JsonObject obj) {
+        public GenericJson(@NotNull JsonObject obj) {
             super(obj);
         }
     }

--- a/core/src/main/java/xyz/gianlu/librespot/mercury/MercuryRequests.java
+++ b/core/src/main/java/xyz/gianlu/librespot/mercury/MercuryRequests.java
@@ -103,6 +103,11 @@ public final class MercuryRequests {
     }
 
     @NotNull
+    public static JsonMercuryRequest<GeneralJson> generalJsonGet(@NotNull String uri) {
+        return new JsonMercuryRequest<>(RawMercuryRequest.get(uri), GeneralJson.class);
+    }
+
+    @NotNull
     private static String getAsString(@NotNull JsonObject obj, @NotNull String key) {
         JsonElement elm = obj.get(key);
         if (elm == null) throw new IllegalArgumentException("Unexpected null value for " + key);
@@ -156,6 +161,13 @@ public final class MercuryRequests {
     public static final class KeymasterToken extends JsonWrapper {
 
         public KeymasterToken(@NotNull JsonObject obj) {
+            super(obj);
+        }
+    }
+
+    public static final class GeneralJson extends JsonWrapper {
+
+        public GeneralJson(@NotNull JsonObject obj) {
             super(obj);
         }
     }


### PR DESCRIPTION
This PR adds `/profile/{user_id}/followers` and `/profile/{user_id}/following` to the API.
It can be used to get the users and artists that a specified user is following or followed by.

* Add ability to query followers of profiles
* Add GeneralJson wrapper for generic json responses
* Add statusCode field to MercuryException
* Update README.md