### PR TITLE
[api] Allow to set volume as a relative step count

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -17,7 +17,7 @@ All the endpoints will respond with `200` if successful or:
 - `POST /player/next` Skip to next track.
 - `POST /player/prev` Skip to previous track.
 - `POST /player/seek` Seek to a given position in ms specified by `pos`.
-- `POST /player/set-volume` Set volume to a given `volume` value from 0 to 65536.
+- `POST /player/set-volume` Either set volume to a given `volume` value (from 0 to 65536), or change it by a `step` count (positive or negative).
 - `POST /player/volume-up` Up the volume a little bit.
 - `POST /player/volume-down` Lower the volume a little bit.
 - `POST /player/current` Retrieve information about the current track (metadata and time).

--- a/player/src/main/java/xyz/gianlu/librespot/player/Player.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/Player.java
@@ -86,13 +86,21 @@ public class Player implements Closeable, DeviceStateHandler.Listener, PlayerSes
     // ================================ //
 
     public void volumeUp() {
+        this.volumeUp(1);
+    }
+
+    public void volumeUp(int steps) {
         if (state == null) return;
-        setVolume(Math.min(Player.VOLUME_MAX, state.getVolume() + oneVolumeStep()));
+        setVolume(Math.min(Player.VOLUME_MAX, state.getVolume() + steps * oneVolumeStep()));
     }
 
     public void volumeDown() {
+        this.volumeDown(1);
+    }
+
+    public void volumeDown(int steps) {
         if (state == null) return;
-        setVolume(Math.max(0, state.getVolume() - oneVolumeStep()));
+        setVolume(Math.max(0, state.getVolume() - steps * oneVolumeStep()));
     }
 
     private int oneVolumeStep() {


### PR DESCRIPTION
Fixes https://github.com/librespot-org/librespot-java/issues/272 by allowing a client to increase the volume by 10 steps (or decrease it by 5 steps).

To be discussed:
  - I don't accept both `volume` and `step` being present, but we could change this to give precedence to `volume` instead.
  - As the player already has volume clamping in its `volumeUp`/`volumeDown` logic, I don't validate that `step` is in any range.
  - The player could have a unique `changeVolume(int steps)` method instead of overloading `volumeUp` and `volumeDown`


```
# Valid requests
$ curl -X POST -d "step=10" localhost:24879/player/set-volume
$ curl -X POST -d "step=-5" localhost:24879/player/set-volume
$ curl -X POST -d "volume=30000" localhost:24879/player/set-volume

# Invalid input: both present
$ curl -X POST -d "step=15&volume=30000" localhost:24879/player/set-volume
{"name":"step","reason":"Cannot be passed alongside volume"}

# Invalid input on existing volume param
$ curl -X POST -d "volume=-30000" localhost:24879/player/set-volume
{"name":"volume","reason":"Must be >= 0 and <= 65536"}

# Invalid input on new step param
$ curl -X POST -d "step=0" localhost:24879/player/set-volume
{"name":"step","reason":"Must be non zero"}
$ curl -X POST -d "step=A" localhost:24879/player/set-volume
{"name":"step","reason":"Not an integer"}
```