### PR TITLE
proxy authentification fix

### DIFF
--- a/lib/src/main/java/xyz/gianlu/librespot/core/Session.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/core/Session.java
@@ -1230,8 +1230,11 @@ public final class Session implements Closeable, SubListener, DealerClient.Messa
 
                     out.write(String.format("CONNECT %s:%d HTTP/1.0\n", apAddr, apPort).getBytes());
                     if (conf.proxyAuth) {
-                        out.write("Proxy-Authorization: Basic ".getBytes());
-                        out.write(Base64.getEncoder().encodeToString(String.format("%s:%s\n", conf.proxyUsername, conf.proxyPassword).getBytes()).getBytes());
+                        String auth1 = "Proxy-Authorization: Basic";
+                        String auth2 = String.format("%s:%s",conf.proxyUsername, conf.proxyPassword);
+                        String auth2coded = Base64.getEncoder().encodeToString(auth2.getBytes());
+                        String authFinal = String.format("%s %s\n",auth1, auth2coded);
+                        out.write(authFinal.getBytes());
                     }
 
                     out.write('\n');

--- a/lib/src/main/java/xyz/gianlu/librespot/core/Session.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/core/Session.java
@@ -1229,13 +1229,8 @@ public final class Session implements Closeable, SubListener, DealerClient.Messa
                     DataInputStream in = new DataInputStream(sock.getInputStream());
 
                     out.write(String.format("CONNECT %s:%d HTTP/1.0\n", apAddr, apPort).getBytes());
-                    if (conf.proxyAuth) {
-                        String auth1 = "Proxy-Authorization: Basic";
-                        String auth2 = String.format("%s:%s",conf.proxyUsername, conf.proxyPassword);
-                        String auth2coded = Base64.getEncoder().encodeToString(auth2.getBytes());
-                        String authFinal = String.format("%s %s\n",auth1, auth2coded);
-                        out.write(authFinal.getBytes());
-                    }
+                    if (conf.proxyAuth)
+                        out.write(String.format("Proxy-Authorization: %s\n", Credentials.basic(conf.proxyUsername, conf.proxyPassword)).getBytes());
 
                     out.write('\n');
                     out.flush();


### PR DESCRIPTION
using a proxy with username and password authentification needing the username:password being base64 encoded

Syntax:
Proxy-Authorization: type credentials
example: 
Proxy-Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l


only credentials have to be encoded, not the whole request. this fix it