### PR TITLE
Removed redundant calls to getInstance()

### DIFF
--- a/lib/src/main/java/xyz/gianlu/librespot/ZeroconfServer.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/ZeroconfServer.java
@@ -291,12 +291,10 @@ public class ZeroconfServer implements Closeable {
         hmac.update("checksum".getBytes());
         byte[] checksumKey = hmac.doFinal();
 
-        hmac = Mac.getInstance("HmacSHA1");
         hmac.init(new SecretKeySpec(baseKey, "HmacSHA1"));
         hmac.update("encryption".getBytes());
         byte[] encryptionKey = hmac.doFinal();
 
-        hmac = Mac.getInstance("HmacSHA1");
         hmac.init(new SecretKeySpec(checksumKey, "HmacSHA1"));
         hmac.update(encrypted);
         byte[] mac = hmac.doFinal();

--- a/lib/src/main/java/xyz/gianlu/librespot/core/Session.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/core/Session.java
@@ -262,7 +262,6 @@ public final class Session implements Closeable, SubListener, DealerClient.Messa
         }
 
         byte[] dataArray = data.toByteArray();
-        mac = Mac.getInstance("HmacSHA1");
         mac.init(new SecretKeySpec(Arrays.copyOfRange(dataArray, 0, 0x14), "HmacSHA1"));
         mac.update(acc.array());
 


### PR DESCRIPTION
init() already takes care of resetting them to their default state after being used previously.