### PR TITLE
Use slf4j for logging in lib module

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -56,6 +56,26 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j-core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j-slf4j-impl.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.lmax</groupId>
+            <artifactId>disruptor</artifactId>
+            <version>${lmax-disruptor.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- HTTP server -->
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-core</artifactId>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -98,5 +98,12 @@
             <artifactId>commons-net</artifactId>
             <version>3.8.0</version>
         </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
+        </dependency>
     </dependencies>
 </project>

--- a/lib/src/main/java/xyz/gianlu/librespot/audio/AudioKeyManager.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/audio/AudioKeyManager.java
@@ -1,10 +1,10 @@
 package xyz.gianlu.librespot.audio;
 
 import com.google.protobuf.ByteString;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xyz.gianlu.librespot.common.Utils;
 import xyz.gianlu.librespot.core.PacketsReceiver;
 import xyz.gianlu.librespot.core.Session;
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public final class AudioKeyManager implements PacketsReceiver {
     private static final byte[] ZERO_SHORT = new byte[]{0, 0};
-    private static final Logger LOGGER = LogManager.getLogger(AudioKeyManager.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AudioKeyManager.class);
     private static final long AUDIO_KEY_REQUEST_TIMEOUT = 2000;
     private final AtomicInteger seqHolder = new AtomicInteger(0);
     private final Map<Integer, Callback> callbacks = Collections.synchronizedMap(new HashMap<>());
@@ -109,7 +109,7 @@ public final class AudioKeyManager implements PacketsReceiver {
 
         @Override
         public void error(short code) {
-            LOGGER.fatal("Audio key error, code: {}", code);
+            LOGGER.error("Audio key error, code: {}", code);
 
             synchronized (reference) {
                 reference.set(null);

--- a/lib/src/main/java/xyz/gianlu/librespot/audio/NormalizationData.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/audio/NormalizationData.java
@@ -1,9 +1,9 @@
 package xyz.gianlu.librespot.audio;
 
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -15,7 +15,7 @@ import java.nio.ByteOrder;
  * @author Gianlu
  */
 public class NormalizationData {
-    private static final Logger LOGGER = LogManager.getLogger(NormalizationData.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(NormalizationData.class);
     public final float track_gain_db;
     public final float track_peak;
     public final float album_gain_db;

--- a/lib/src/main/java/xyz/gianlu/librespot/audio/PlayableContentFeeder.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/audio/PlayableContentFeeder.java
@@ -6,11 +6,11 @@ import com.spotify.storage.StorageResolve.StorageResolveResponse;
 import okhttp3.HttpUrl;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xyz.gianlu.librespot.audio.cdn.CdnFeedHelper;
 import xyz.gianlu.librespot.audio.cdn.CdnManager;
 import xyz.gianlu.librespot.audio.format.AudioQualityPicker;
@@ -30,7 +30,7 @@ import java.util.List;
  * @author Gianlu
  */
 public final class PlayableContentFeeder {
-    private static final Logger LOGGER = LogManager.getLogger(PlayableContentFeeder.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlayableContentFeeder.class);
     private static final String STORAGE_RESOLVE_INTERACTIVE = "/storage-resolve/files/audio/interactive/%s";
     private static final String STORAGE_RESOLVE_INTERACTIVE_PREFETCH = "/storage-resolve/files/audio/interactive_prefetch/%s";
     protected final Session session;
@@ -84,7 +84,7 @@ public final class PlayableContentFeeder {
             String country = session.countryCode();
             if (country != null) ContentRestrictedException.checkRestrictions(country, original.getRestrictionList());
 
-            LOGGER.fatal("Couldn't find playable track: " + id.toSpotifyUri());
+            LOGGER.error("Couldn't find playable track: " + id.toSpotifyUri());
             throw new FeederException();
         }
 
@@ -134,7 +134,7 @@ public final class PlayableContentFeeder {
     private LoadedStream loadTrack(@NotNull Metadata.Track track, @NotNull AudioQualityPicker audioQualityPicker, boolean preload, @Nullable HaltListener haltListener) throws IOException, CdnManager.CdnException, MercuryClient.MercuryException {
         Metadata.AudioFile file = audioQualityPicker.getFile(track.getFileList());
         if (file == null) {
-            LOGGER.fatal("Couldn't find any suitable audio file, available: {}", Utils.formatsToString(track.getFileList()));
+            LOGGER.error("Couldn't find any suitable audio file, available: {}", Utils.formatsToString(track.getFileList()));
             throw new FeederException();
         }
 
@@ -150,7 +150,7 @@ public final class PlayableContentFeeder {
         } else {
             Metadata.AudioFile file = audioQualityPicker.getFile(episode.getAudioList());
             if (file == null) {
-                LOGGER.fatal("Couldn't find any suitable audio file, available: {}", Utils.formatsToString(episode.getAudioList()));
+                LOGGER.error("Couldn't find any suitable audio file, available: {}", Utils.formatsToString(episode.getAudioList()));
                 throw new FeederException();
             }
 

--- a/lib/src/main/java/xyz/gianlu/librespot/audio/cdn/CdnFeedHelper.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/audio/cdn/CdnFeedHelper.java
@@ -5,10 +5,10 @@ import com.spotify.storage.StorageResolve.StorageResolveResponse;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xyz.gianlu.librespot.audio.HaltListener;
 import xyz.gianlu.librespot.audio.NormalizationData;
 import xyz.gianlu.librespot.audio.PlayableContentFeeder;
@@ -23,7 +23,7 @@ import java.io.InputStream;
  * @author Gianlu
  */
 public final class CdnFeedHelper {
-    private static final Logger LOGGER = LogManager.getLogger(CdnFeedHelper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CdnFeedHelper.class);
 
     private CdnFeedHelper() {
     }

--- a/lib/src/main/java/xyz/gianlu/librespot/audio/cdn/CdnManager.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/audio/cdn/CdnManager.java
@@ -4,10 +4,10 @@ import com.google.protobuf.ByteString;
 import com.spotify.metadata.Metadata;
 import com.spotify.storage.StorageResolve.StorageResolveResponse;
 import okhttp3.*;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xyz.gianlu.librespot.audio.*;
 import xyz.gianlu.librespot.audio.decrypt.AesAudioDecrypt;
 import xyz.gianlu.librespot.audio.decrypt.AudioDecrypt;
@@ -33,7 +33,7 @@ import static xyz.gianlu.librespot.audio.storage.ChannelManager.CHUNK_SIZE;
  * @author Gianlu
  */
 public class CdnManager {
-    private static final Logger LOGGER = LogManager.getLogger(CdnManager.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CdnManager.class);
     private final Session session;
 
     public CdnManager(@NotNull Session session) {
@@ -294,7 +294,7 @@ public class CdnManager {
                         return;
                     }
                 } catch (IOException | CacheManager.BadChunkHashException ex) {
-                    LOGGER.fatal("Failed requesting chunk from cache, index: {}", index, ex);
+                    LOGGER.error("Failed requesting chunk from cache, index: {}", index, ex);
                 }
             }
 
@@ -302,7 +302,7 @@ public class CdnManager {
                 InternalResponse resp = request(index);
                 writeChunk(resp.buffer, index, false);
             } catch (IOException | CdnException ex) {
-                LOGGER.fatal("Failed requesting chunk from network, index: {}", index, ex);
+                LOGGER.error("Failed requesting chunk from network, index: {}", index, ex);
                 internalStream.notifyChunkError(index, new AbsChunkedInputStream.ChunkException(ex));
             }
         }

--- a/lib/src/main/java/xyz/gianlu/librespot/audio/storage/AudioFileFetch.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/audio/storage/AudioFileFetch.java
@@ -1,9 +1,9 @@
 package xyz.gianlu.librespot.audio.storage;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xyz.gianlu.librespot.audio.AbsChunkedInputStream;
 import xyz.gianlu.librespot.cache.CacheManager;
 import xyz.gianlu.librespot.common.Utils;
@@ -19,7 +19,7 @@ import static xyz.gianlu.librespot.audio.storage.ChannelManager.CHUNK_SIZE;
 public class AudioFileFetch implements AudioFile {
     public static final byte HEADER_SIZE = 0x3;
     public static final byte HEADER_CDN = 0x4;
-    private static final Logger LOGGER = LogManager.getLogger(AudioFileFetch.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AudioFileFetch.class);
     private final CacheManager.Handler cache;
     private int size = -1;
     private int chunks = -1;
@@ -65,7 +65,7 @@ public class AudioFileFetch implements AudioFile {
 
     @Override
     public synchronized void streamError(int chunkIndex, short code) {
-        LOGGER.fatal("Stream error, index: {}, code: {}", chunkIndex, code);
+        LOGGER.error("Stream error, index: {}, code: {}", chunkIndex, code);
 
         exception = AbsChunkedInputStream.ChunkException.fromStreamError(code);
         notifyAll();

--- a/lib/src/main/java/xyz/gianlu/librespot/audio/storage/AudioFileStreaming.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/audio/storage/AudioFileStreaming.java
@@ -2,10 +2,10 @@ package xyz.gianlu.librespot.audio.storage;
 
 import com.google.protobuf.ByteString;
 import com.spotify.metadata.Metadata;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xyz.gianlu.librespot.audio.AbsChunkedInputStream;
 import xyz.gianlu.librespot.audio.GeneralAudioStream;
 import xyz.gianlu.librespot.audio.HaltListener;
@@ -28,7 +28,7 @@ import java.util.concurrent.Executors;
  * @author Gianlu
  */
 public class AudioFileStreaming implements AudioFile, GeneralAudioStream {
-    private static final Logger LOGGER = LogManager.getLogger(AudioFileStreaming.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AudioFileStreaming.class);
     private final CacheManager.Handler cacheHandler;
     private final Metadata.AudioFile file;
     private final byte[] key;
@@ -72,7 +72,7 @@ public class AudioFileStreaming implements AudioFile, GeneralAudioStream {
             try {
                 session.channel().requestChunk(fileId, index, file);
             } catch (IOException ex) {
-                LOGGER.fatal("Failed requesting chunk from network, index: {}", index, ex);
+                LOGGER.error("Failed requesting chunk from network, index: {}", index, ex);
                 chunksBuffer.internalStream.notifyChunkError(index, new AbsChunkedInputStream.ChunkException(ex));
             }
         }
@@ -84,7 +84,7 @@ public class AudioFileStreaming implements AudioFile, GeneralAudioStream {
             cacheHandler.readChunk(index, this);
             return true;
         } catch (IOException | CacheManager.BadChunkHashException ex) {
-            LOGGER.fatal("Failed requesting chunk from cache, index: {}", index, ex);
+            LOGGER.error("Failed requesting chunk from cache, index: {}", index, ex);
             return false;
         }
     }
@@ -147,7 +147,7 @@ public class AudioFileStreaming implements AudioFile, GeneralAudioStream {
 
     @Override
     public void streamError(int chunkIndex, short code) {
-        LOGGER.fatal("Stream error, index: {}, code: {}", chunkIndex, code);
+        LOGGER.error("Stream error, index: {}, code: {}", chunkIndex, code);
         chunksBuffer.internalStream.notifyChunkError(chunkIndex, AbsChunkedInputStream.ChunkException.fromStreamError(code));
     }
 

--- a/lib/src/main/java/xyz/gianlu/librespot/audio/storage/ChannelManager.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/audio/storage/ChannelManager.java
@@ -1,9 +1,9 @@
 package xyz.gianlu.librespot.audio.storage;
 
 import com.google.protobuf.ByteString;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xyz.gianlu.librespot.common.NameThreadFactory;
 import xyz.gianlu.librespot.common.Utils;
 import xyz.gianlu.librespot.core.PacketsReceiver;
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class ChannelManager implements Closeable, PacketsReceiver {
     public static final int CHUNK_SIZE = 128 * 1024;
-    private static final Logger LOGGER = LogManager.getLogger(ChannelManager.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChannelManager.class);
     private final Map<Short, Channel> channels = new HashMap<>();
     private final AtomicInteger seqHolder = new AtomicInteger(0);
     private final ExecutorService executorService = Executors.newCachedThreadPool(new NameThreadFactory(r -> "channel-queue-" + r.hashCode()));
@@ -167,7 +167,7 @@ public class ChannelManager implements Closeable, PacketsReceiver {
                             break;
                         }
                     } catch (IOException ex) {
-                        LOGGER.fatal("Failed handling packet!", ex);
+                        LOGGER.error("Failed handling packet!", ex);
                     } catch (InterruptedException ex) {
                         break;
                     }

--- a/lib/src/main/java/xyz/gianlu/librespot/cache/CacheManager.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/cache/CacheManager.java
@@ -1,9 +1,9 @@
 package xyz.gianlu.librespot.cache;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xyz.gianlu.librespot.audio.GeneralWritableStream;
 import xyz.gianlu.librespot.audio.StreamId;
 import xyz.gianlu.librespot.common.Utils;
@@ -28,7 +28,7 @@ import static xyz.gianlu.librespot.audio.storage.ChannelManager.CHUNK_SIZE;
  */
 public class CacheManager implements Closeable {
     private static final long CLEAN_UP_THRESHOLD = TimeUnit.DAYS.toMillis(7);
-    private static final Logger LOGGER = LogManager.getLogger(CacheManager.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CacheManager.class);
     /**
      * The header indicating when the file was last read or written to.
      */

--- a/lib/src/main/java/xyz/gianlu/librespot/common/AsyncProcessor.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/common/AsyncProcessor.java
@@ -1,9 +1,9 @@
 package xyz.gianlu.librespot.common;
 
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.util.concurrent.ExecutorService;
@@ -20,7 +20,7 @@ import java.util.function.Function;
  * @param <RES> Return type of our processor implementation
  */
 public class AsyncProcessor<REQ, RES> implements Closeable {
-    private static final Logger LOGGER = LogManager.getLogger(AsyncProcessor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AsyncProcessor.class);
     private final String name;
     private final Function<REQ, RES> processor;
     private final ExecutorService executor;

--- a/lib/src/main/java/xyz/gianlu/librespot/common/Log4JUncaughtExceptionHandler.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/common/Log4JUncaughtExceptionHandler.java
@@ -1,17 +1,17 @@
 package xyz.gianlu.librespot.common;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author devgianlu
  */
 public class Log4JUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
-    private static final Logger LOGGER = LogManager.getLogger(Log4JUncaughtExceptionHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Log4JUncaughtExceptionHandler.class);
 
     @Override
     public void uncaughtException(@NotNull Thread t, Throwable e) {
-        LOGGER.fatal("[{}]", t.getName(), e);
+        LOGGER.error("[{}]", t.getName(), e);
     }
 }

--- a/lib/src/main/java/xyz/gianlu/librespot/common/ProtoUtils.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/common/ProtoUtils.java
@@ -12,11 +12,11 @@ import com.spotify.context.ContextPageOuterClass.ContextPage;
 import com.spotify.context.ContextPlayerOptionsOuterClass;
 import com.spotify.metadata.Metadata;
 import com.spotify.playlist4.Playlist4ApiProto;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xyz.gianlu.librespot.metadata.PlayableId;
 import xyz.gianlu.librespot.metadata.UnsupportedId;
 
@@ -31,7 +31,7 @@ import static com.spotify.context.PlayOriginOuterClass.PlayOrigin;
  * @author Gianlu
  */
 public final class ProtoUtils {
-    private static final Logger LOGGER = LogManager.getLogger(ProtoUtils.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProtoUtils.class);
 
     private ProtoUtils() {
     }

--- a/lib/src/main/java/xyz/gianlu/librespot/common/Utils.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/common/Utils.java
@@ -5,11 +5,11 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.protobuf.ByteString;
 import com.spotify.metadata.Metadata;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.sound.sampled.Mixer;
 import java.io.ByteArrayOutputStream;
@@ -28,7 +28,7 @@ import java.util.*;
  */
 public final class Utils {
     private final static char[] hexArray = "0123456789ABCDEF".toCharArray();
-    private static final Logger LOGGER = LogManager.getLogger(Utils.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Utils.class);
     private static final String randomString = "abcdefghijklmnopqrstuvwxyz0123456789";
 
     private Utils() {

--- a/lib/src/main/java/xyz/gianlu/librespot/core/ApResolver.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/core/ApResolver.java
@@ -4,9 +4,9 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -25,7 +25,7 @@ import java.util.concurrent.ThreadLocalRandom;
 public final class ApResolver {
     private static final String BASE_URL = "http://apresolve.spotify.com/";
     private static final Map<String, List<String>> pool = new HashMap<>(3);
-    private static final Logger LOGGER = LogManager.getLogger(ApResolver.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApResolver.class);
     private static volatile boolean poolReady = false;
 
     public static void fillPool() throws IOException {

--- a/lib/src/main/java/xyz/gianlu/librespot/core/EventService.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/core/EventService.java
@@ -1,9 +1,9 @@
 package xyz.gianlu.librespot.core;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xyz.gianlu.librespot.common.AsyncWorker;
 import xyz.gianlu.librespot.mercury.MercuryClient;
 import xyz.gianlu.librespot.mercury.RawMercuryRequest;
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit;
  * @author Gianlu
  */
 public final class EventService implements Closeable {
-    private final static Logger LOGGER = LogManager.getLogger(EventService.class);
+    private final static Logger LOGGER = LoggerFactory.getLogger(EventService.class);
     private final AsyncWorker<EventBuilder> asyncWorker;
 
     EventService(@NotNull Session session) {

--- a/lib/src/main/java/xyz/gianlu/librespot/core/FacebookAuthenticator.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/core/FacebookAuthenticator.java
@@ -4,9 +4,9 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.protobuf.ByteString;
 import com.spotify.Authentication;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xyz.gianlu.librespot.Version;
 import xyz.gianlu.librespot.common.NetUtils;
 import xyz.gianlu.librespot.common.Utils;
@@ -24,7 +24,7 @@ import java.util.Base64;
  */
 public final class FacebookAuthenticator implements Closeable {
     private static final URL LOGIN_SPOTIFY;
-    private static final Logger LOGGER = LogManager.getLogger(FacebookAuthenticator.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FacebookAuthenticator.class);
     private static final byte[] EOL = new byte[]{'\r', '\n'};
 
     static {
@@ -75,7 +75,7 @@ public final class FacebookAuthenticator implements Closeable {
     private void authData(@NotNull String json) {
         JsonObject obj = JsonParser.parseString(json).getAsJsonObject();
         if (!obj.get("error").isJsonNull()) {
-            LOGGER.fatal("Error during authentication: " + obj.get("error"));
+            LOGGER.error("Error during authentication: " + obj.get("error"));
             return;
         }
 
@@ -156,7 +156,7 @@ public final class FacebookAuthenticator implements Closeable {
                     }
                 }
             } catch (IOException ex) {
-                LOGGER.fatal("Failed polling Spotify credentials URL!", ex);
+                LOGGER.error("Failed polling Spotify credentials URL!", ex);
             }
         }
     }

--- a/lib/src/main/java/xyz/gianlu/librespot/core/Session.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/core/Session.java
@@ -13,10 +13,10 @@ import okhttp3.*;
 import okio.BufferedSink;
 import okio.GzipSink;
 import okio.Okio;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -57,7 +57,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @author Gianlu
  */
 public final class Session implements Closeable {
-    private static final Logger LOGGER = LogManager.getLogger(Session.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Session.class);
     private static final byte[] serverKey = new byte[]{
             (byte) 0xac, (byte) 0xe0, (byte) 0x46, (byte) 0x0b, (byte) 0xff, (byte) 0xc2, (byte) 0x30, (byte) 0xaf, (byte) 0xf4, (byte) 0x6b, (byte) 0xfe, (byte) 0xc3,
             (byte) 0xbf, (byte) 0xbf, (byte) 0x86, (byte) 0x3d, (byte) 0xa1, (byte) 0x91, (byte) 0xc6, (byte) 0xcc, (byte) 0x33, (byte) 0x6c, (byte) 0x93, (byte) 0xa1,
@@ -1283,7 +1283,7 @@ public final class Session implements Closeable {
                     }
                 } catch (IOException | GeneralSecurityException ex) {
                     if (running) {
-                        LOGGER.fatal("Failed reading packet!", ex);
+                        LOGGER.error("Failed reading packet!", ex);
                         reconnect();
                     }
 
@@ -1305,7 +1305,7 @@ public final class Session implements Closeable {
                         try {
                             send(Packet.Type.Pong, packet.payload);
                         } catch (IOException ex) {
-                            LOGGER.fatal("Failed sending Pong!", ex);
+                            LOGGER.error("Failed sending Pong!", ex);
                         }
                         break;
                     case PongAck:

--- a/lib/src/main/java/xyz/gianlu/librespot/core/TimeProvider.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/core/TimeProvider.java
@@ -6,9 +6,9 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.apache.commons.net.ntp.NTPUDPClient;
 import org.apache.commons.net.ntp.TimeInfo;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xyz.gianlu.librespot.mercury.MercuryClient;
 
 import java.io.IOException;
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public final class TimeProvider {
     private static final AtomicLong offset = new AtomicLong(0);
-    private static final Logger LOGGER = LogManager.getLogger(TimeProvider.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TimeProvider.class);
     private static Method method = Method.NTP;
 
     private TimeProvider() {

--- a/lib/src/main/java/xyz/gianlu/librespot/core/TokenProvider.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/core/TokenProvider.java
@@ -2,10 +2,10 @@ package xyz.gianlu.librespot.core;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xyz.gianlu.librespot.common.Utils;
 import xyz.gianlu.librespot.mercury.MercuryClient;
 import xyz.gianlu.librespot.mercury.MercuryRequests;
@@ -20,7 +20,7 @@ import java.util.Objects;
  * @author Gianlu
  */
 public final class TokenProvider {
-    private final static Logger LOGGER = LogManager.getLogger(TokenProvider.class);
+    private final static Logger LOGGER = LoggerFactory.getLogger(TokenProvider.class);
     private final static int TOKEN_EXPIRE_THRESHOLD = 10;
     private final Session session;
     private final List<StoredToken> tokens = new ArrayList<>();

--- a/lib/src/main/java/xyz/gianlu/librespot/dealer/ApiClient.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/dealer/ApiClient.java
@@ -6,10 +6,10 @@ import com.spotify.extendedmetadata.ExtendedMetadata;
 import com.spotify.metadata.Metadata;
 import okhttp3.*;
 import okio.BufferedSink;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xyz.gianlu.librespot.core.ApResolver;
 import xyz.gianlu.librespot.core.Session;
 import xyz.gianlu.librespot.mercury.MercuryClient;
@@ -24,7 +24,7 @@ import static com.spotify.canvaz.CanvazOuterClass.EntityCanvazResponse;
  * @author Gianlu
  */
 public class ApiClient {
-    private static final Logger LOGGER = LogManager.getLogger(ApiClient.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiClient.class);
     private final Session session;
     private final String baseUrl;
 

--- a/lib/src/main/java/xyz/gianlu/librespot/dealer/DealerClient.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/dealer/DealerClient.java
@@ -7,10 +7,10 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xyz.gianlu.librespot.common.AsyncWorker;
 import xyz.gianlu.librespot.common.BytesArrayList;
 import xyz.gianlu.librespot.common.NameThreadFactory;
@@ -30,7 +30,7 @@ import java.util.zip.GZIPInputStream;
  * @author Gianlu
  */
 public class DealerClient implements Closeable {
-    private static final Logger LOGGER = LogManager.getLogger(DealerClient.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DealerClient.class);
     private final AsyncWorker<Runnable> asyncWorker;
     private final Session session;
     private final Map<String, RequestListener> reqListeners = new HashMap<>();
@@ -324,7 +324,7 @@ public class DealerClient implements Closeable {
             @Override
             public void onOpen(@NotNull WebSocket ws, @NotNull Response response) {
                 if (closed || scheduler.isShutdown()) {
-                    LOGGER.fatal("I wonder what happened here... Terminating. {closed: {}}", closed);
+                    LOGGER.error("I wonder what happened here... Terminating. {closed: {}}", closed);
                     return;
                 }
 

--- a/lib/src/main/java/xyz/gianlu/librespot/mercury/MercuryClient.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/mercury/MercuryClient.java
@@ -6,10 +6,10 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.spotify.Mercury;
 import com.spotify.Pubsub;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xyz.gianlu.librespot.common.BytesArrayList;
 import xyz.gianlu.librespot.common.ProtobufToJson;
 import xyz.gianlu.librespot.common.Utils;
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @author Gianlu
  */
 public final class MercuryClient implements PacketsReceiver, Closeable {
-    private static final Logger LOGGER = LogManager.getLogger(MercuryClient.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MercuryClient.class);
     private static final int MERCURY_REQUEST_TIMEOUT = 3000;
     private final AtomicInteger seqHolder = new AtomicInteger(1);
     private final Map<Long, Callback> callbacks = Collections.synchronizedMap(new HashMap<>());
@@ -197,7 +197,7 @@ public final class MercuryClient implements PacketsReceiver, Closeable {
         try {
             header = Mercury.Header.parseFrom(partial.get(0));
         } catch (InvalidProtocolBufferException ex) {
-            LOGGER.fatal("Couldn't parse header! {bytes: {}}", Utils.bytesToHex(partial.get(0)));
+            LOGGER.error("Couldn't parse header! {bytes: {}}", Utils.bytesToHex(partial.get(0)));
             return;
         }
 

--- a/player/pom.xml
+++ b/player/pom.xml
@@ -68,6 +68,25 @@
             <version>1.0.2-gdx</version>
         </dependency>
 
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j-core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j-slf4j-impl.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.lmax</groupId>
+            <artifactId>disruptor</artifactId>
+            <version>${lmax-disruptor.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- TOML configuration -->
         <dependency>
             <groupId>com.electronwill.night-config</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,9 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <gson.version>2.8.6</gson.version>
         <protobuf.version>3.15.8</protobuf.version>
+        <log4j-core.version>2.13.3</log4j-core.version>
+        <log4j-slf4j-impl.version>2.14.1</log4j-slf4j-impl.version>
+        <lmax-disruptor.version>3.4.2</lmax-disruptor.version>
     </properties>
 
     <modules>
@@ -53,25 +56,6 @@
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>20.1.0</version>
-        </dependency>
-
-        <!-- Logging -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.13.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.14.1</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.lmax</groupId>
-            <artifactId>disruptor</artifactId>
-            <version>3.4.2</version>
-            <scope>runtime</scope>
         </dependency>
 
         <!-- Unit tests -->


### PR DESCRIPTION
Using slf4j in the lib module makes a lot more sense because we don't include the actual logging engine that is log4j in our case. Also request in #335.