### PR TITLE
Use SLF4J API's in player module instead of Log4J 

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,6 +21,7 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - name: Import GPG secrets
+        if: ${{ !startsWith(github.ref, 'refs/pull') }}
         run: |
           echo $GPG_SECRET_KEYS | base64 --decode > gpg-private-key.txt
           gpg --pinentry-mode loopback --import --batch gpg-private-key.txt
@@ -40,6 +41,7 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: mvn clean test -Pdebug -B -U -Dgpg.skip -Dmaven.javadoc.skip=true
       - name: Deploy with Maven to OSSRH
+        if: ${{ !startsWith(github.ref, 'refs/pull') }}
         run: mvn deploy --settings .maven.xml -B -U -Possrh
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/player/pom.xml
+++ b/player/pom.xml
@@ -91,6 +91,11 @@
             <version>${lmax-disruptor.version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j-api.version}</version>
+        </dependency>
 
         <!-- TOML configuration -->
         <dependency>

--- a/player/src/main/java/xyz/gianlu/librespot/player/FileConfiguration.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/FileConfiguration.java
@@ -13,8 +13,8 @@ import com.electronwill.nightconfig.core.io.ConfigWriter;
 import com.electronwill.nightconfig.toml.TomlParser;
 import com.spotify.connectstate.Connect;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.gianlu.librespot.ZeroconfServer;
@@ -37,7 +37,7 @@ import java.util.function.Supplier;
  * @author devgianlu
  */
 public final class FileConfiguration {
-    private static final Logger LOGGER = LogManager.getLogger(FileConfiguration.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileConfiguration.class);
 
     static {
         FormatDetector.registerExtension("properties", new PropertiesFormat());

--- a/player/src/main/java/xyz/gianlu/librespot/player/StateWrapper.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/StateWrapper.java
@@ -19,8 +19,8 @@ import com.spotify.transfer.QueueOuterClass;
 import com.spotify.transfer.SessionOuterClass;
 import com.spotify.transfer.TransferStateOuterClass;
 import okhttp3.*;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.gianlu.librespot.common.FisherYatesShuffle;
@@ -46,7 +46,7 @@ import java.util.function.Function;
  * @author Gianlu
  */
 public class StateWrapper implements DeviceStateHandler.Listener, DealerClient.MessageListener, Closeable {
-    private static final Logger LOGGER = LogManager.getLogger(StateWrapper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(StateWrapper.class);
 
     static {
         try {

--- a/player/src/main/java/xyz/gianlu/librespot/player/codecs/Codec.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/codecs/Codec.java
@@ -1,7 +1,7 @@
 package xyz.gianlu.librespot.player.codecs;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.gianlu.librespot.audio.AbsChunkedInputStream;
@@ -19,7 +19,7 @@ import java.io.OutputStream;
  */
 public abstract class Codec implements Closeable {
     public static final int BUFFER_SIZE = 2048;
-    private static final Logger LOGGER = LogManager.getLogger(Codec.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Codec.class);
     protected final AbsChunkedInputStream audioIn;
     protected final float normalizationFactor;
     protected final int duration;
@@ -70,7 +70,7 @@ public abstract class Codec implements Closeable {
                     throw new IOException(String.format("Failed seeking, skip: %d, skipped: %d", skip, skipped));
             }
         } catch (IOException ex) {
-            LOGGER.fatal("Failed seeking!", ex);
+            LOGGER.error("Failed seeking!", ex);
         }
     }
 

--- a/player/src/main/java/xyz/gianlu/librespot/player/codecs/VorbisOnlyAudioQuality.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/codecs/VorbisOnlyAudioQuality.java
@@ -1,8 +1,8 @@
 package xyz.gianlu.librespot.player.codecs;
 
 import com.spotify.metadata.Metadata;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.gianlu.librespot.audio.format.AudioQualityPicker;
@@ -15,7 +15,7 @@ import java.util.List;
  * @author Gianlu
  */
 public final class VorbisOnlyAudioQuality implements AudioQualityPicker {
-    private static final Logger LOGGER = LogManager.getLogger(VorbisOnlyAudioQuality.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(VorbisOnlyAudioQuality.class);
     private final AudioQuality preferred;
 
     public VorbisOnlyAudioQuality(@NotNull AudioQuality preferred) {
@@ -41,7 +41,7 @@ public final class VorbisOnlyAudioQuality implements AudioQualityPicker {
             if (vorbis != null)
                 LOGGER.warn("Using {} because preferred {} couldn't be found.", vorbis.getFormat(), preferred);
             else
-                LOGGER.fatal("Couldn't find any Vorbis file, available: {}", Utils.formatsToString(files));
+                LOGGER.error("Couldn't find any Vorbis file, available: {}", Utils.formatsToString(files));
         }
 
         return vorbis;

--- a/player/src/main/java/xyz/gianlu/librespot/player/crossfade/CrossfadeController.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/crossfade/CrossfadeController.java
@@ -3,8 +3,8 @@ package xyz.gianlu.librespot.player.crossfade;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.gianlu.librespot.metadata.PlayableId;
@@ -15,7 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class CrossfadeController {
-    private static final Logger LOGGER = LogManager.getLogger(CrossfadeController.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CrossfadeController.class);
     private final String playbackId;
     private final int trackDuration;
     private final Map<Reason, FadeInterval> fadeOutMap = new HashMap<>(8);

--- a/player/src/main/java/xyz/gianlu/librespot/player/events/EventsMetadataPipe.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/events/EventsMetadataPipe.java
@@ -1,7 +1,7 @@
 package xyz.gianlu.librespot.player.events;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
@@ -32,7 +32,7 @@ public final class EventsMetadataPipe implements Player.EventsListener, Closeabl
     private static final String CODE_PRGR = "70726772";
     private static final String CODE_PICT = "50494354";
     private static final String CODE_PFLS = "70666C73";
-    private static final Logger LOGGER = LogManager.getLogger(EventsMetadataPipe.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventsMetadataPipe.class);
     private final File file;
     private FileOutputStream out;
 

--- a/player/src/main/java/xyz/gianlu/librespot/player/events/EventsShell.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/events/EventsShell.java
@@ -1,7 +1,7 @@
 package xyz.gianlu.librespot.player.events;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
@@ -16,7 +16,7 @@ import java.io.IOException;
  * @author devgianlu
  */
 public final class EventsShell implements Player.EventsListener, Session.@NotNull ReconnectionListener {
-    private static final Logger LOGGER = LogManager.getLogger(EventsShell.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventsShell.class);
     private final Configuration conf;
     private final Runtime runtime;
 

--- a/player/src/main/java/xyz/gianlu/librespot/player/metrics/PlaybackMetrics.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/metrics/PlaybackMetrics.java
@@ -1,7 +1,7 @@
 package xyz.gianlu.librespot.player.metrics;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.gianlu.librespot.core.Session;
@@ -17,7 +17,7 @@ import java.util.List;
  * @author devgianlu
  */
 public class PlaybackMetrics {
-    private static final Logger LOGGER = LogManager.getLogger(PlaybackMetrics.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlaybackMetrics.class);
     public final PlayableId id;
     final String playbackId;
     final String featureVersion;

--- a/player/src/main/java/xyz/gianlu/librespot/player/mixing/MixingLine.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/mixing/MixingLine.java
@@ -1,7 +1,7 @@
 package xyz.gianlu.librespot.player.mixing;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.gianlu.librespot.player.codecs.Codec;
@@ -14,7 +14,7 @@ import java.io.OutputStream;
  * @author Gianlu
  */
 public final class MixingLine extends InputStream {
-    private static final Logger LOGGER = LogManager.getLogger(MixingLine.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MixingLine.class);
     boolean switchFormat = false;
     private GainAwareCircularBuffer fcb;
     private GainAwareCircularBuffer scb;

--- a/player/src/main/java/xyz/gianlu/librespot/player/playback/PlayerQueue.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/playback/PlayerQueue.java
@@ -1,7 +1,7 @@
 package xyz.gianlu.librespot.player.playback;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -17,7 +17,7 @@ import java.util.concurrent.Executors;
  * @author devgianlu
  */
 final class PlayerQueue implements Closeable {
-    private static final Logger LOGGER = LogManager.getLogger(PlayerQueue.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlayerQueue.class);
     private final ExecutorService executorService = Executors.newCachedThreadPool(new NameThreadFactory((r) -> "player-queue-" + r.hashCode()));
     private PlayerQueueEntry head = null;
 

--- a/player/src/main/java/xyz/gianlu/librespot/player/playback/PlayerQueueEntry.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/playback/PlayerQueueEntry.java
@@ -1,8 +1,8 @@
 package xyz.gianlu.librespot.player.playback;
 
 import javazoom.jl.decoder.BitstreamException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.gianlu.librespot.audio.HaltListener;
@@ -43,7 +43,7 @@ class PlayerQueueEntry extends PlayerQueue.Entry implements Closeable, Runnable,
     static final int INSTANT_PRELOAD = 1;
     static final int INSTANT_START_NEXT = 2;
     static final int INSTANT_END = 3;
-    private static final Logger LOGGER = LogManager.getLogger(PlayerQueueEntry.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlayerQueueEntry.class);
     final PlayableId playable;
     final String playbackId;
     private final PlayerConfiguration conf;

--- a/player/src/main/java/xyz/gianlu/librespot/player/playback/PlayerSession.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/playback/PlayerSession.java
@@ -1,7 +1,7 @@
 package xyz.gianlu.librespot.player.playback;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -31,7 +31,7 @@ import java.util.concurrent.Executors;
  * @author devgianlu
  */
 public class PlayerSession implements Closeable, PlayerQueueEntry.Listener {
-    private static final Logger LOGGER = LogManager.getLogger(PlayerSession.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlayerSession.class);
     private final ExecutorService executorService = Executors.newCachedThreadPool(new NameThreadFactory((r) -> "player-session-" + r.hashCode()));
     private final Session session;
     private final AudioSink sink;

--- a/player/src/main/java/xyz/gianlu/librespot/player/state/DeviceStateHandler.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/state/DeviceStateHandler.java
@@ -9,8 +9,8 @@ import com.spotify.connectstate.Connect;
 import com.spotify.connectstate.Player;
 import com.spotify.context.ContextTrackOuterClass.ContextTrack;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.gianlu.librespot.Version;
@@ -34,7 +34,7 @@ import java.util.*;
  * @author Gianlu
  */
 public final class DeviceStateHandler implements Closeable, DealerClient.MessageListener, DealerClient.RequestListener {
-    private static final Logger LOGGER = LogManager.getLogger(DeviceStateHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeviceStateHandler.class);
 
     static {
         try {
@@ -155,7 +155,7 @@ public final class DeviceStateHandler implements Closeable, DealerClient.Message
             Connect.ClusterUpdate update = Connect.ClusterUpdate.parseFrom(payload);
 
             long now = TimeProvider.currentTimeMillis();
-            LOGGER.trace("Received cluster update at {}: {}", () -> now, () -> TextFormat.shortDebugString(update));
+            LOGGER.trace("Received cluster update at {}: {}", now, TextFormat.shortDebugString(update));
 
             long ts = update.getCluster().getTimestamp() - 3000; // Workaround
             if (!session.deviceId().equals(update.getCluster().getActiveDeviceId()) && isActive() && now > startedPlayingAt() && ts > startedPlayingAt())
@@ -243,7 +243,7 @@ public final class DeviceStateHandler implements Closeable, DealerClient.Message
     private void putConnectState(@NotNull Connect.PutStateRequest req) {
         try {
             session.api().putConnectState(connectionId, req);
-            if (LOGGER.getLevel().isLessSpecificThan(Level.TRACE)) {
+            if (LOGGER.isTraceEnabled()) {
                 LOGGER.info("Put state. {ts: {}, connId: {}, reason: {}, request: {}}", req.getClientSideTimestamp(),
                         Utils.truncateMiddle(connectionId, 10), req.getPutStateReason(), TextFormat.shortDebugString(putState));
             } else {

--- a/player/src/main/java/xyz/gianlu/librespot/player/state/DeviceStateHandler.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/state/DeviceStateHandler.java
@@ -8,11 +8,10 @@ import com.google.protobuf.TextFormat;
 import com.spotify.connectstate.Connect;
 import com.spotify.connectstate.Player;
 import com.spotify.context.ContextTrackOuterClass.ContextTrack;
-import org.apache.logging.log4j.Level;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xyz.gianlu.librespot.Version;
 import xyz.gianlu.librespot.common.AsyncWorker;
 import xyz.gianlu.librespot.common.ProtoUtils;
@@ -155,7 +154,8 @@ public final class DeviceStateHandler implements Closeable, DealerClient.Message
             Connect.ClusterUpdate update = Connect.ClusterUpdate.parseFrom(payload);
 
             long now = TimeProvider.currentTimeMillis();
-            LOGGER.trace("Received cluster update at {}: {}", now, TextFormat.shortDebugString(update));
+            if (LOGGER.isTraceEnabled())
+                LOGGER.trace("Received cluster update at {}: {}", now, TextFormat.shortDebugString(update));
 
             long ts = update.getCluster().getTimestamp() - 3000; // Workaround
             if (!session.deviceId().equals(update.getCluster().getActiveDeviceId()) && isActive() && now > startedPlayingAt() && ts > startedPlayingAt())


### PR DESCRIPTION
Originally I just asked for the lib-module to utilize SLF4J. But as the player module is now intended to be used on Android it should use Android-friendly logging as well.
The way it is done should allow to keep LOG4J as default. In case the runtime is Android one will need to force exclude LOG4J from the dependencies in gradle and add a SLF4J compatible wrapper for the Android Logging System.

**Remarks**

1. Line 158 in DeviceStateHandler - Lambdas were used as parameters for the log call. This seems not supported with SLF4J therefore I referenced the paramters straight.
2. Line 246 in DeviceStateHandler - I assumed you intended to log the first log message variant in case of level TRACE and translated to SLF4J API accordingly.
3. I can't avoid merge commits with github it seems. I hope that is ok