### PR TITLE
Handle some Exceptions caused eg. by missing network during shutdown

### DIFF
--- a/player/src/main/java/xyz/gianlu/librespot/player/state/DeviceStateHandler.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/state/DeviceStateHandler.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.*;
+import java.util.concurrent.RejectedExecutionException;
 
 /**
  * @author Gianlu
@@ -226,7 +227,11 @@ public final class DeviceStateHandler implements Closeable, DealerClient.Message
                 .setClientSideTimestamp(TimeProvider.currentTimeMillis())
                 .getDeviceBuilder().setDeviceInfo(deviceInfo).setPlayerState(state);
 
-        putStateWorker.submit(putState.build());
+        try {
+        	putStateWorker.submit(putState.build());
+        } catch (RejectedExecutionException e){
+            LOGGER.debug("Failed to update state, ignoring.", e);
+        }
     }
 
     public synchronized int getVolume() {


### PR DESCRIPTION
If you close the player for example during missing network or while a reconnect is in progress, some issues might occur and cause uncaught Exceptions.
This PR fixes the most occurring issues.

This might especially be required if you use librespot-java on a mobile client like Android.