### PR TITLE
HTTPS proxy support

### DIFF
--- a/player/src/main/java/xyz/gianlu/librespot/player/FileConfiguration.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/FileConfiguration.java
@@ -411,6 +411,7 @@ public final class FileConfiguration {
                 .setTimeManualCorrection(config.get("time.manualCorrection"))
                 .setProxyEnabled(config.get("proxy.enabled"))
                 .setProxyType(config.getEnum("proxy.type", Proxy.Type.class))
+                .setProxySSL(config.get("proxy.ssl"))
                 .setProxyAddress(config.get("proxy.address"))
                 .setProxyPort(config.get("proxy.port"))
                 .setProxyAuth(config.get("proxy.auth"))

--- a/player/src/main/resources/default.toml
+++ b/player/src/main/resources/default.toml
@@ -58,6 +58,7 @@ host = "0.0.0.0" # API listen interface (`api` module only)
 [proxy] ### Proxy ###
 enabled = false # Whether the proxy is enabled
 type = "HTTP" # The proxy type (HTTP, SOCKS)
+ssl = false # Connect to proxy using SSL (HTTP only)
 address = "" # The proxy hostname
 port = 0 # The proxy port
 auth = false # Whether authentication is enabled on the server


### PR DESCRIPTION
Uses SSLSocketFactory to create the proxy socket, otherwise identical to using an HTTP proxy.

As Proxy.Type is used throughout the code and does not support HTTPS a proxySSL flag was added to Session.Configuration, and proxy.ssl was added to the config file.