### PR TITLE
feat: Add GET /instance endpoint, which returns some basic information about the current session

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -42,6 +42,7 @@ All the endpoints will respond with `200` if successful or:
 - `GET /profile/{user_id}/following` Retrieve a list of profiles that the specified user is following
 
 ### Instance
+- `GET /instance` Returns a json model that contains basic information about the current session; `device_id`, `device_name`,`device_type`, `country_code`, and `preferred_locale`
 - `POST /instance/terminate` Terminates the API server.
 - `POST /instance/close` Closes the current session (and player).
 

--- a/api/src/main/java/xyz/gianlu/librespot/api/ApiServer.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/ApiServer.java
@@ -45,6 +45,7 @@ public class ApiServer {
                 .post("/token/{scope}", new TokensHandler(wrapper))
                 .post("/profile/{user_id}/{action}", new ProfileHandler(wrapper))
                 .post("/web-api/{endpoint}", new WebApiHandler(wrapper))
+                .get("/instance", InstanceHandler.forSession(this, wrapper))
                 .post("/instance/{action}", InstanceHandler.forSession(this, wrapper))
                 .post("/discovery/{action}", new DiscoveryHandler())
                 .get("/events", events)

--- a/api/src/main/java/xyz/gianlu/librespot/api/ApiServer.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/ApiServer.java
@@ -35,6 +35,8 @@ public class ApiServer {
     private Undertow undertow = null;
 
     public ApiServer(int port, @NotNull String host, @NotNull SessionWrapper wrapper) {
+        AbsSessionHandler instanceHandler = InstanceHandler.forSession(this, wrapper);
+
         this.port = port;
         this.host = host;
         this.wrapper = wrapper;
@@ -45,8 +47,8 @@ public class ApiServer {
                 .post("/token/{scope}", new TokensHandler(wrapper))
                 .post("/profile/{user_id}/{action}", new ProfileHandler(wrapper))
                 .post("/web-api/{endpoint}", new WebApiHandler(wrapper))
-                .get("/instance", InstanceHandler.forSession(this, wrapper))
-                .post("/instance/{action}", InstanceHandler.forSession(this, wrapper))
+                .get("/instance", instanceHandler)
+                .post("/instance/{action}", instanceHandler)
                 .post("/discovery/{action}", new DiscoveryHandler())
                 .get("/events", events)
                 .setFallbackHandler(new PathHandler(ResponseCodeHandler.HANDLE_404)

--- a/api/src/main/java/xyz/gianlu/librespot/api/Utils.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/Utils.java
@@ -83,4 +83,9 @@ public final class Utils {
         exchange.setStatusCode(StatusCodes.INTERNAL_SERVER_ERROR);
         exchange.getResponseSender().send(String.format(INTERNAL_ERROR_BODY, reason));
     }
+
+    public static void methodNotAllowed(@NotNull HttpServerExchange exchange) {
+        exchange.setStatusCode(StatusCodes.METHOD_NOT_ALLOWED);
+        exchange.getResponseSender().send(StatusCodes.METHOD_NOT_ALLOWED_STRING);
+    }
 }

--- a/api/src/main/java/xyz/gianlu/librespot/api/handlers/InstanceHandler.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/handlers/InstanceHandler.java
@@ -104,7 +104,7 @@ public final class InstanceHandler {
                             session.close();
                             break;
                         default:
-                            Utils.invalidParameter(exchange, "action");
+                            Utils.methodNotAllowed(exchange);
                             break;
                     }
                     break;
@@ -150,7 +150,7 @@ public final class InstanceHandler {
                             session.close();
                             break;
                         default:
-                            Utils.invalidParameter(exchange, "action");
+                            Utils.methodNotAllowed(exchange);
                             break;
                     }
                     break;


### PR DESCRIPTION
- Endpoint addition, main intention is to provide an alternative to using the `web-api` for basic information about the session including `device_id`, `device_name`, and `device_type`
- `device_id`, `device_name`,`device_type`, `country_code`, and `preferred_locale`

Example request:
```json
{
    "device_id": "22ed0b3e74ad2001d16b7ea751fc58bb7a1ae686",
    "device_name": "librespot-java",
    "device_type": "COMPUTER",
    "country_code": "US",
    "preferred_locale": "en"
}
```