### PR TITLE
Make ApResolver use the proxy (if there's one configured)

### DIFF
--- a/lib/src/main/java/xyz/gianlu/librespot/core/ApResolver.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/core/ApResolver.java
@@ -62,7 +62,7 @@ public final class ApResolver {
     }
 
     @NotNull
-    private List<String> getUrls(@NotNull JsonObject body, @NotNull String type) {
+    private static List<String> getUrls(@NotNull JsonObject body, @NotNull String type) {
         JsonArray aps = body.getAsJsonArray(type);
         List<String> list = new ArrayList<>(aps.size());
         for (JsonElement ap : aps) list.add(ap.getAsString());

--- a/lib/src/main/java/xyz/gianlu/librespot/core/ApResolver.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/core/ApResolver.java
@@ -23,6 +23,7 @@ import com.google.gson.JsonParser;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,9 +82,10 @@ public final class ApResolver {
         Request request = new Request.Builder()
                 .url(url.toString())
                 .build();
-        Response response = client.newCall(request).execute();
-        if (response.isSuccessful()) {
-            try (Reader reader = response.body().charStream()) {
+        try (Response response = client.newCall(request).execute()) {
+            ResponseBody body = response.body();
+            if (body == null) throw new IOException("No body");
+            try (Reader reader = body.charStream()) {
                 JsonObject obj = JsonParser.parseReader(reader).getAsJsonObject();
                 HashMap<String, List<String>> map = new HashMap<>();
                 for (String type : types)

--- a/lib/src/main/java/xyz/gianlu/librespot/core/ApResolver.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/core/ApResolver.java
@@ -62,8 +62,7 @@ public final class ApResolver {
         return list;
     }
 
-    @NotNull
-    private static Map<String, List<String>> request(@NotNull String... types) throws IOException {
+    private static void request(@NotNull String... types) throws IOException {
         if (types.length == 0) throw new IllegalArgumentException();
 
         StringBuilder url = new StringBuilder(BASE_URL + "?");
@@ -88,8 +87,6 @@ public final class ApResolver {
             }
 
             LOGGER.info("Loaded aps into pool: " + pool);
-
-            return map;
         } finally {
             conn.disconnect();
         }

--- a/lib/src/main/java/xyz/gianlu/librespot/dealer/ApiClient.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/dealer/ApiClient.java
@@ -46,7 +46,7 @@ public final class ApiClient {
 
     public ApiClient(@NotNull Session session) {
         this.session = session;
-        this.baseUrl = "https://" + ApResolver.getRandomSpclient();
+        this.baseUrl = "https://" + session.apResolver().getRandomSpclient();
     }
 
     @NotNull

--- a/lib/src/main/java/xyz/gianlu/librespot/dealer/DealerClient.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/dealer/DealerClient.java
@@ -31,7 +31,6 @@ import xyz.gianlu.librespot.common.AsyncWorker;
 import xyz.gianlu.librespot.common.BytesArrayList;
 import xyz.gianlu.librespot.common.NameThreadFactory;
 import xyz.gianlu.librespot.common.Utils;
-import xyz.gianlu.librespot.core.ApResolver;
 import xyz.gianlu.librespot.core.Session;
 import xyz.gianlu.librespot.mercury.MercuryClient;
 
@@ -76,7 +75,7 @@ public class DealerClient implements Closeable {
      */
     public synchronized void connect() throws IOException, MercuryClient.MercuryException {
         conn = new ConnectionHolder(session, new Request.Builder()
-                .url(String.format("wss://%s/?access_token=%s", ApResolver.getRandomDealer(), session.tokens().get("playlist-read")))
+                .url(String.format("wss://%s/?access_token=%s", session.apResolver().getRandomDealer(), session.tokens().get("playlist-read")))
                 .build());
     }
 


### PR DESCRIPTION
With the old implementation, the ap request wasn't going through the proxy (if there was one configured). Now, it uses the OkHttpClient we use in other parts of the app which will be configured to use the proxy if needed.