### PR TITLE
Expose exception class name and message as shell env. variables

### DIFF
--- a/player/src/main/java/xyz/gianlu/librespot/player/ShellEvents.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/ShellEvents.java
@@ -90,7 +90,7 @@ public final class ShellEvents implements Player.EventsListener, Session.Reconne
 
     @Override
     public void onPlaybackFailed(@NotNull Player player, Exception e) {
-        exec(conf.onPlaybackFailed, "EXCEPTION=" + e.getMessage());
+        exec(conf.onPlaybackFailed, "EXCEPTION=" + e.getClass().getCanonicalName(), "MESSAGE=" + e.getMessage());
     }
 
     @Override


### PR DESCRIPTION
Sorry for the multiple PRs.

I've modified the shell event for onPlaybackFailed to expose both the exception class name and the message, which might help with error handling for some people.