### PR TITLE
Refresh the AP pool after stopping the receiver

### DIFF
--- a/api/src/main/java/xyz/gianlu/librespot/api/handlers/EventsHandler.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/handlers/EventsHandler.java
@@ -94,7 +94,8 @@ public final class EventsHandler extends WebSocketProtocolHandshakeHandler imple
     public void onPlaybackFailed(@NotNull Player player, @NotNull Exception e) {
         JsonObject obj = new JsonObject();
         obj.addProperty("event", "playbackFailed");
-        obj.addProperty("exception", e.getMessage());
+        obj.addProperty("exception", e.getClass().getCanonicalName());
+        obj.addProperty("message", e.getMessage());
         dispatch(obj);
     }
 

--- a/api/src/main/java/xyz/gianlu/librespot/api/handlers/EventsHandler.java
+++ b/api/src/main/java/xyz/gianlu/librespot/api/handlers/EventsHandler.java
@@ -91,7 +91,7 @@ public final class EventsHandler extends WebSocketProtocolHandshakeHandler imple
     }
 
     @Override
-    public void onPlaybackFailed(@NotNull Player player, Exception e) {
+    public void onPlaybackFailed(@NotNull Player player, @NotNull Exception e) {
         JsonObject obj = new JsonObject();
         obj.addProperty("event", "playbackFailed");
         obj.addProperty("exception", e.getMessage());

--- a/lib/src/main/java/xyz/gianlu/librespot/core/ApResolver.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/core/ApResolver.java
@@ -85,20 +85,18 @@ public final class ApResolver {
         try (Response response = client.newCall(request).execute()) {
             ResponseBody body = response.body();
             if (body == null) throw new IOException("No body");
-            try (Reader reader = body.charStream()) {
-                JsonObject obj = JsonParser.parseReader(reader).getAsJsonObject();
-                HashMap<String, List<String>> map = new HashMap<>();
-                for (String type : types)
-                    map.put(type, getUrls(obj, type));
+            JsonObject obj = JsonParser.parseReader(body.charStream()).getAsJsonObject();
+            HashMap<String, List<String>> map = new HashMap<>();
+            for (String type : types)
+                map.put(type, getUrls(obj, type));
 
-                synchronized (pool) {
-                    pool.putAll(map);
-                    poolReady = true;
-                    pool.notifyAll();
-                }
-
-                LOGGER.info("Loaded aps into pool: " + pool);
+            synchronized (pool) {
+                pool.putAll(map);
+                poolReady = true;
+                pool.notifyAll();
             }
+
+            LOGGER.info("Loaded aps into pool: " + pool);
         }
     }
 

--- a/lib/src/main/java/xyz/gianlu/librespot/core/Session.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/core/Session.java
@@ -718,12 +718,12 @@ public final class Session implements Closeable {
         }
 
         try {
-            apResolver.refreshPool();
-
             if (conn != null) {
-                conn.socket.close();
                 receiver.stop();
+                conn.socket.close();
             }
+
+            apResolver.refreshPool();
 
             conn = ConnectionHolder.create(apResolver.getRandomAccesspoint(), inner.conf);
             connect();

--- a/player/src/main/java/xyz/gianlu/librespot/player/Player.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/Player.java
@@ -872,7 +872,7 @@ public class Player implements Closeable {
 
         void onPlaybackResumed(@NotNull Player player, long trackTime);
 
-        void onPlaybackFailed(@NotNull Player player, Exception e);
+        void onPlaybackFailed(@NotNull Player player, @NotNull Exception e);
 
         void onTrackSeeked(@NotNull Player player, long trackTime);
 
@@ -1005,7 +1005,7 @@ public class Player implements Closeable {
                     }
 
                     @Override
-                    public void onPlaybackFailed(@NotNull Player player, Exception e) {
+                    public void onPlaybackFailed(@NotNull Player player, @NotNull Exception e) {
                     }
 
                     @Override
@@ -1082,7 +1082,7 @@ public class Player implements Closeable {
                 executorService.execute(() -> l.onPlaybackResumed(Player.this, trackTime));
         }
 
-        void playbackFailed(Exception ex) {
+        void playbackFailed(@NotNull Exception ex) {
             for (EventsListener l : new ArrayList<>(listeners))
                 executorService.execute(() -> l.onPlaybackFailed(Player.this, ex));
         }

--- a/player/src/main/java/xyz/gianlu/librespot/player/ShellEvents.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/ShellEvents.java
@@ -89,7 +89,7 @@ public final class ShellEvents implements Player.EventsListener, Session.Reconne
     }
 
     @Override
-    public void onPlaybackFailed(@NotNull Player player, Exception e) {
+    public void onPlaybackFailed(@NotNull Player player, @NotNull Exception e) {
         exec(conf.onPlaybackFailed, "EXCEPTION=" + e.getClass().getCanonicalName(), "MESSAGE=" + e.getMessage());
     }
 


### PR DESCRIPTION
Before, we tried to refresh the AP pool before stopping the receiver. If the AP pool refresh failed it would throw an exception and the receiver would not be stopped, making it trying to access a null pointer afterwards. This should fix https://github.com/librespot-org/librespot-java/issues/447.

This PR also includes some other minor changes related to yesterday's PR (#460) which I overlooked.