### PR TITLE
Allow getting the player's seek time instead of the real time

### DIFF
--- a/player/src/main/java/xyz/gianlu/librespot/player/Player.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/Player.java
@@ -837,6 +837,17 @@ public class Player implements Closeable {
         }
     }
 
+    /**
+     * @return The current seek position of the player or {@code -1} if unavailable (most likely if it's playing an episode).
+     */
+    public int seekTime() {
+        try {
+            return playerSession == null ? -1 : playerSession.currentSeekTime();
+        } catch (Decoder.CannotGetTimeException ex) {
+            return -1;
+        }
+    }
+
 
     // ================================ //
     // ============ Close! ============ //

--- a/player/src/main/java/xyz/gianlu/librespot/player/playback/PlayerQueueEntry.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/playback/PlayerQueueEntry.java
@@ -180,6 +180,19 @@ class PlayerQueueEntry extends PlayerQueue.Entry implements Closeable, Runnable,
     }
 
     /**
+     * Returns the current seek position. This might not be the real player position if it's called right after a seek.
+     *
+     * @return The current seek position of the player or {@code -1} if not ready.
+     * @throws Decoder.CannotGetTimeException If the time is unavailable for the codec being used.
+     */
+    int getSeekTime() throws Decoder.CannotGetTimeException {
+        int seekTime = this.seekTime;
+        if (seekTime != -1) return seekTime;
+        if (decoder != null) return decoder.time();
+        return -1;
+    }
+
+    /**
      * Returns the current position.
      *
      * @return The current position of the player or {@code -1} if not available.

--- a/player/src/main/java/xyz/gianlu/librespot/player/playback/PlayerSession.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/playback/PlayerSession.java
@@ -345,6 +345,15 @@ public class PlayerSession implements Closeable, PlayerQueueEntry.Listener {
         else return queue.head().getTime();
     }
 
+    /**
+     * @return The seek time for the current head or {@code -1} if not available.
+     * @throws Decoder.CannotGetTimeException If the head is available, but time cannot be retrieved
+     */
+    public int currentSeekTime() throws Decoder.CannotGetTimeException {
+        if (queue.head() == null) return -1;
+        else return queue.head().getSeekTime();
+    }
+
     @Nullable
     public String currentPlaybackId() {
         if (queue.head() == null) return null;


### PR DESCRIPTION
The new method returns the desired seek time if available, or the real time if the player has already sought.

Should fix #448.