### PR TITLE
changes to prevent advance when queue is empty

### DIFF
--- a/player/src/main/java/xyz/gianlu/librespot/player/Player.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/Player.java
@@ -452,8 +452,28 @@ public class Player implements Closeable {
                 }
 
                 if (next.isOk()) {
-                    if (next != NextPlayable.OK_PLAY && next != NextPlayable.OK_REPEAT)
+                    if (next != NextPlayable.OK_PLAY && next != NextPlayable.OK_REPEAT) {
+                        /*
+                        10/1/2023 tagdara - 
+                        This is an attempt to remediate librespot moving to the next track in the queue when there is no next track
+                        in the queue.  In adddition to re-queueing the current track, this introduces several race conditions when another
+                        track replaces it, causing metadata conflicts and multiple playbackEnded events.
+
+                        This is a two part change, which also requires a change in the PlayerSession advanceTo function.
+
+                        Removing the pause and returning null instead of returning state.getCurrentPlayableOrThrow() (the same track) as the 
+                        next playable prevents player confusion about what track is truly up next. 
+                        
+                        This might have an impact on clicking play again on the only track in the queue, but have not experienced this side effect
+                        in testing.
+
                         sink.pause(false);
+                        return state.getCurrentPlayableOrThrow();
+
+                        */
+                        LOGGER.info("PLAYER.NEXTPLAYABLE - [CODE CHANGE TEST] - sending null on pause to prevent advance");
+                        return null;
+                    }
 
                     return state.getCurrentPlayableOrThrow();
                 } else {


### PR DESCRIPTION
One of my use cases plays a track from a list on demand without filling the spotify queue.  Currently librespot-java will throw an exception when reaching the end of the queue and attempt to reload the current track as if it is the head of the queue.  This causes a number of issues.

- An exception every time the end of the queue is reached.
- A reload of the metadata for the existing track, which often does not complete before the next track is added.
- Race conditions on the reload, and multiple playbackEnded messages on the websocket.

While I've been using elaborate error handling on my client app to resolve these problems, it often results in skipped tracks or no track loaded.  These two changes attempt to prevent the loop back to the same track when the queue ends.