### PR TITLE
Support new format for Expires url parameter in CDN Manager

### DIFF
--- a/lib/src/main/java/xyz/gianlu/librespot/audio/cdn/CdnManager.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/audio/cdn/CdnManager.java
@@ -158,6 +158,10 @@ public class CdnManager {
 
             if (fileId != null) {
                 String tokenStr = url.queryParameter("__token__");
+                // Existing format: https://aud...bcf?__token__=exp=1697904087~hmac=80...99
+                String expiresStr = url.queryParameter("Expires");
+                // New https://aud...bcf?Expires=1697904086~FullPath~hmac=fT...Q=
+
                 if (tokenStr != null && !tokenStr.isEmpty()) {
                     Long expireAt = null;
                     String[] split = tokenStr.split("~");
@@ -178,6 +182,18 @@ public class CdnManager {
                     }
 
                     expiration = expireAt * 1000;
+                    
+                } else if ( expiresStr != null && !expiresStr.isEmpty()) {
+                    Long expireAt = null;
+                    String expiresStrVal = expiresStr.split("~")[0];
+                    expireAt = Long.parseLong(expiresStrVal);
+                    if (expireAt == null) {
+                        expiration = -1;
+                        LOGGER.warn("Invalid Expires param in CDN url: " + url);
+                    }
+
+                    expiration = expireAt * 1000;
+
                 } else {
                     String param = url.queryParameterName(0);
                     int i = param.indexOf('_');


### PR DESCRIPTION
In the last few days I noticed a number of track crashes or skips and discovered errors in the log similar to this:

2023-10-19 22:39:36,593 WARN  CdnManager:186 - Couldn't extract expiration, invalid parameter in CDN url: https://audio4-gm-fb.spotifycdn.com/audio/b2...43?Expires=1697866776~FullPath~hmac=_Pl...t0=

Supported formats previously came in two flavors:
- one where the expires value was just sent as part of the name of the url parameter:
https://audio4-fa.scdn.co/audio/09...51?1697904085_be...9L-IF-tO...bU=

- one where __token__ was used and exp was parsed out:
https://audio4-ak-spotify-com.akamaized.net/audio/0f...cf?__token__=exp=1697904087~hmac=80...99 

I added support for this new Expires parameter into setUrl in the CDN Manager, matching the format of the code which checks the __token__ version

