### PR TITLE
Ignore spotifycdn.com subdoms

### DIFF
--- a/lib/src/main/java/xyz/gianlu/librespot/audio/NormalizationData.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/audio/NormalizationData.java
@@ -62,13 +62,19 @@ public class NormalizationData {
         return new NormalizationData(buffer.getFloat(), buffer.getFloat(), buffer.getFloat(), buffer.getFloat());
     }
 
-    public float getFactor(float normalisationPregain) {
-        float normalisationFactor = (float) Math.pow(10, (track_gain_db + normalisationPregain) / 20);
+    public float getFactor(float normalisationPregain, boolean useAlbumGain) {
+        float gain = useAlbumGain? album_gain_db : track_gain_db;
+        LOGGER.trace("Using gain: {}", gain);
+        float normalisationFactor = (float) Math.pow(10, (gain + normalisationPregain) / 20);
         if (normalisationFactor * track_peak > 1) {
             LOGGER.warn("Reducing normalisation factor to prevent clipping. Please add negative pregain to avoid.");
             normalisationFactor = 1 / track_peak;
         }
 
         return normalisationFactor;
+    }
+
+    public float getFactor(float normalisationPregain) {
+        return getFactor(normalisationPregain, false);
     }
 }

--- a/lib/src/main/java/xyz/gianlu/librespot/core/Session.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/core/Session.java
@@ -70,6 +70,8 @@ import java.security.spec.RSAPublicKeySpec;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
 
 /**
  * @author Gianlu
@@ -144,6 +146,14 @@ public final class Session implements Closeable {
     private static OkHttpClient createClient(@NotNull Configuration conf) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.retryOnConnectionFailure(true);
+        builder.hostnameVerifier(new HostnameVerifier() {
+            @Override
+            public boolean verify(String hostname, SSLSession session) {
+                if (hostname.toLowerCase().endsWith("spotifycdn.com") && session.getPeerHost().toLowerCase().endsWith("spotifycdn.com"))
+                    return true;
+                return hostname.equalsIgnoreCase(session.getPeerHost());
+            }
+        });
 
         if (conf.proxyEnabled && conf.proxyType != Proxy.Type.DIRECT) {
             builder.proxy(new Proxy(conf.proxyType, new InetSocketAddress(conf.proxyAddress, conf.proxyPort)));

--- a/player/src/main/java/xyz/gianlu/librespot/player/FileConfiguration.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/FileConfiguration.java
@@ -439,6 +439,7 @@ public final class FileConfiguration {
                 .setAutoplayEnabled(config.get("player.autoplayEnabled"))
                 .setCrossfadeDuration(config.get("player.crossfadeDuration"))
                 .setEnableNormalisation(config.get("player.enableNormalisation"))
+                .setUseAlbumGain(config.get("player.useAlbumGain"))
                 .setInitialVolume(config.get("player.initialVolume"))
                 .setLogAvailableMixers(config.get("player.logAvailableMixers"))
                 .setMetadataPipe(metadataPipe())

--- a/player/src/main/java/xyz/gianlu/librespot/player/PlayerConfiguration.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/PlayerConfiguration.java
@@ -29,6 +29,7 @@ public final class PlayerConfiguration {
     // Audio
     public final AudioQuality preferredQuality;
     public final boolean enableNormalisation;
+    public final boolean useAlbumGain;
     public final float normalisationPregain;
     public final boolean autoplayEnabled;
     public final int crossfadeDuration;
@@ -52,11 +53,12 @@ public final class PlayerConfiguration {
     // Local files
     public final File localFilesPath;
 
-    private PlayerConfiguration(AudioQuality preferredQuality, boolean enableNormalisation, float normalisationPregain, boolean autoplayEnabled, int crossfadeDuration, boolean preloadEnabled,
+    private PlayerConfiguration(AudioQuality preferredQuality, boolean enableNormalisation, boolean useAlbumGain, float normalisationPregain, boolean autoplayEnabled, int crossfadeDuration, boolean preloadEnabled,
                                 AudioOutput output, String outputClass, Object[] outputClassParams, File outputPipe, File metadataPipe, String[] mixerSearchKeywords, boolean logAvailableMixers, int releaseLineDelay,
                                 int initialVolume, int volumeSteps, boolean bypassSinkVolume, File localFilesPath) {
         this.preferredQuality = preferredQuality;
         this.enableNormalisation = enableNormalisation;
+        this.useAlbumGain = useAlbumGain;
         this.normalisationPregain = normalisationPregain;
         this.autoplayEnabled = autoplayEnabled;
         this.crossfadeDuration = crossfadeDuration;
@@ -83,6 +85,7 @@ public final class PlayerConfiguration {
         // Audio
         private AudioQuality preferredQuality = AudioQuality.NORMAL;
         private boolean enableNormalisation = true;
+        private boolean useAlbumGain = false;
         private float normalisationPregain = 3.0f;
         private boolean autoplayEnabled = true;
         private int crossfadeDuration = 0;
@@ -116,6 +119,11 @@ public final class PlayerConfiguration {
 
         public Builder setEnableNormalisation(boolean enableNormalisation) {
             this.enableNormalisation = enableNormalisation;
+            return this;
+        }
+
+        public Builder setUseAlbumGain(boolean useAlbumGain) {
+            this.useAlbumGain = useAlbumGain;
             return this;
         }
 
@@ -207,7 +215,7 @@ public final class PlayerConfiguration {
 
         @Contract(value = " -> new", pure = true)
         public @NotNull PlayerConfiguration build() {
-            return new PlayerConfiguration(preferredQuality, enableNormalisation, normalisationPregain, autoplayEnabled, crossfadeDuration, preloadEnabled,
+            return new PlayerConfiguration(preferredQuality, enableNormalisation, useAlbumGain, normalisationPregain, autoplayEnabled, crossfadeDuration, preloadEnabled,
                     output, outputClass, outputClassParams, outputPipe, metadataPipe, mixerSearchKeywords, logAvailableMixers, releaseLineDelay,
                     initialVolume, volumeSteps, bypassSinkVolume, localFilesPath);
         }

--- a/player/src/main/java/xyz/gianlu/librespot/player/playback/PlayerQueueEntry.java
+++ b/player/src/main/java/xyz/gianlu/librespot/player/playback/PlayerQueueEntry.java
@@ -135,7 +135,7 @@ class PlayerQueueEntry extends PlayerQueue.Entry implements Closeable, Runnable,
 
         float normalizationFactor;
         if (stream.normalizationData == null || !conf.enableNormalisation) normalizationFactor = 1;
-        else normalizationFactor = stream.normalizationData.getFactor(conf.normalisationPregain);
+        else normalizationFactor = stream.normalizationData.getFactor(conf.normalisationPregain, conf.useAlbumGain);
 
         Iterator<Decoder> iter = Decoders.initDecoder(stream.in.codec(), stream.in.stream(), normalizationFactor, metadata.duration());
         while (iter.hasNext()) {

--- a/player/src/main/resources/default.toml
+++ b/player/src/main/resources/default.toml
@@ -37,6 +37,7 @@ manualCorrection = 0 # Manual time correction in millis
 autoplayEnabled = true # Autoplay similar songs when your music ends
 preferredAudioQuality = "NORMAL" # Preferred audio quality (NORMAL, HIGH, VERY_HIGH)
 enableNormalisation = true # Whether to apply the Spotify loudness normalisation
+useAlbumGain = false # Whether to apply album gain (instead of track gain) for normalisation
 normalisationPregain = +3.0 # Normalisation pregain in decibels (loud at +6, normal at +3, quiet at -5)
 initialVolume = 65536 # Initial volume (0-65536)
 volumeSteps = 64 # Number of volume notches


### PR DESCRIPTION
Spotify seems to have misconfigured some of their hosts or TLS certs:

javax.net.ssl.SSLPeerUnverifiedException: Hostname audio4-gm-fb.spotifycdn.com not verified:
    certificate: sha256/mikb4l8fq5rYJv+AdSiChROLrTKpCEENcVFH4engaDw=
    DN: CN=audio-gm-off.spotifycdn.com
    subjectAltNames: [audio-gm-off.spotifycdn.com]

This patch ignores the host / subdomain part if both the cert and the host we want to connect to end in spotifycdn.com.
This is a hack for misconfigured servers, but security implications should be close to zero.
