### PR TITLE
hack: ignore TLS hostname verification for spotifycdn.com

### DIFF
--- a/lib/src/main/java/xyz/gianlu/librespot/core/Session.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/core/Session.java
@@ -70,6 +70,8 @@ import java.security.spec.RSAPublicKeySpec;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
 
 /**
  * @author Gianlu
@@ -144,6 +146,14 @@ public final class Session implements Closeable {
     private static OkHttpClient createClient(@NotNull Configuration conf) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.retryOnConnectionFailure(true);
+        builder.hostnameVerifier(new HostnameVerifier() {
+            @Override
+            public boolean verify(String hostname, SSLSession session) {
+                if (hostname.toLowerCase().endsWith(".spotifycdn.com") && session.getPeerHost().toLowerCase().endsWith(".spotifycdn.com"))
+                    return true;
+                return hostname.equalsIgnoreCase(session.getPeerHost());
+            }
+        });
 
         if (conf.proxyEnabled && conf.proxyType != Proxy.Type.DIRECT) {
             builder.proxy(new Proxy(conf.proxyType, new InetSocketAddress(conf.proxyAddress, conf.proxyPort)));


### PR DESCRIPTION
Spotify seems to have misconfigured some of their hosts or TLS certs:

javax.net.ssl.SSLPeerUnverifiedException: Hostname audio4-gm-fb.spotifycdn.com not verified:
certificate: sha256/mikb4l8fq5rYJv+AdSiChROLrTKpCEENcVFH4engaDw=
DN: CN=audio-gm-off.spotifycdn.com
subjectAltNames: [audio-gm-off.spotifycdn.com]

This patch ignores the host / subdomain part if both the cert and the host we want to connect to end in spotifycdn.com.
This is a hack for misconfigured servers, but security implications should be close to zero.
