### PR TITLE
temporary fixes to CDN feed helper which avoid the broken CDN server

### DIFF
--- a/lib/src/main/java/xyz/gianlu/librespot/audio/cdn/CdnFeedHelper.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/audio/cdn/CdnFeedHelper.java
@@ -46,7 +46,13 @@ public final class CdnFeedHelper {
 
     @NotNull
     private static HttpUrl getUrl(@NotNull Session session, @NotNull StorageResolveResponse resp) {
-        return HttpUrl.get(resp.getCdnurl(session.random().nextInt(resp.getCdnurlCount())));
+        String selectedUrl = resp.getCdnurl(session.random().nextInt(resp.getCdnurlCount()));
+        while (selectedUrl.contains("audio4-gm-fb")) {
+            LOGGER.warn("getUrl picked CDN with known issues {} (forcing re-selection)", selectedUrl );
+            selectedUrl = resp.getCdnurl(session.random().nextInt(resp.getCdnurlCount()));
+        }
+        return HttpUrl.get(selectedUrl);
+        // return HttpUrl.get(resp.getCdnurl(session.random().nextInt(resp.getCdnurlCount())));
     }
 
     public static @NotNull LoadedStream loadTrack(@NotNull Session session, Metadata.@NotNull Track track, Metadata.@NotNull AudioFile file,

--- a/lib/src/main/java/xyz/gianlu/librespot/audio/cdn/CdnFeedHelper.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/audio/cdn/CdnFeedHelper.java
@@ -52,7 +52,6 @@ public final class CdnFeedHelper {
             selectedUrl = resp.getCdnurl(session.random().nextInt(resp.getCdnurlCount()));
         }
         return HttpUrl.get(selectedUrl);
-        // return HttpUrl.get(resp.getCdnurl(session.random().nextInt(resp.getCdnurlCount())));
     }
 
     public static @NotNull LoadedStream loadTrack(@NotNull Session session, Metadata.@NotNull Track track, Metadata.@NotNull AudioFile file,


### PR DESCRIPTION
This is related to the issues in Ssl err #742

Spotify has included a server (audio4-gm-fb) in their CDN rotation which has several issues:
- It has a new Expires format which has been resolved in #736
- It has a bad SSL cert which resolves to 'audio-gm-off'
- It does not properly serve chunks even when those issues are bypassed

This patch watches for the server to be selected, and when it happens, forces a re-selection.  This retains the random logic for CDN selection.

Hopefully Spotify will fix this on the back-end and these patches will no longer be needed