### PR TITLE
ApResolver: Use HTTPS in base URL

### DIFF
--- a/lib/src/main/java/xyz/gianlu/librespot/core/ApResolver.java
+++ b/lib/src/main/java/xyz/gianlu/librespot/core/ApResolver.java
@@ -40,7 +40,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * @author Gianlu
  */
 public final class ApResolver {
-    private static final String BASE_URL = "http://apresolve.spotify.com/";
+    private static final String BASE_URL = "https://apresolve.spotify.com/";
     private static final Logger LOGGER = LoggerFactory.getLogger(ApResolver.class);
 
     private final OkHttpClient client;


### PR DESCRIPTION
Spotify uses HTTPS by default for apresolve.

Modern systems reject HTTP by default:

<img width="682" height="40" alt="image" src="https://github.com/user-attachments/assets/d4efb426-2dfb-4d60-bd1b-becfbabf29af" />
